### PR TITLE
Added Basics singleton, revamped TagResolverFactory, added PAPI support, and more

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 tasks.register("copyAllToTestServer") {
-    group = "testserver"
+    group  = "basics-test"
     description = "Copies the plugin and all modules to the test server"
     dependsOn("plugin:copyPluginToTestServer")
     dependsOn("modules:copyAllModulesToTestServer")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 tasks.register("copyAllToTestServer") {
-    group  = "basics-test"
+    group  = "basics"
     description = "Copies the plugin and all modules to the test server"
     dependsOn("plugin:copyPluginToTestServer")
     dependsOn("modules:copyAllModulesToTestServer")

--- a/buildSrc/src/main/kotlin/basics.module.gradle.kts
+++ b/buildSrc/src/main/kotlin/basics.module.gradle.kts
@@ -40,7 +40,7 @@ tasks.processResources {
 
 val moduleName = project.name
 tasks.register("copyModule${moduleName.pascalCase()}ToTestServer", CopyModule::class) {
-    group = "testserver"
+    group  = "basics-test"
     description = "Copies the ${moduleName} module to the test server"
     from(tasks.getByName("shadowJar", ShadowJar::class).archiveFile)
     into(getServerModulesDirectory())

--- a/common/src/main/kotlin/com/github/spigotbasics/common/SimpleLocation.kt
+++ b/common/src/main/kotlin/com/github/spigotbasics/common/SimpleLocation.kt
@@ -1,9 +1,0 @@
-package com.github.spigotbasics.common
-
-data class SimpleLocation(
-    val world: String,
-    val x: Double,
-    val y: Double,
-    val z: Double,
-    val yaw: Float,
-    val pitch: Float)

--- a/common/src/main/kotlin/com/github/spigotbasics/common/SimpleLocation.kt
+++ b/common/src/main/kotlin/com/github/spigotbasics/common/SimpleLocation.kt
@@ -1,0 +1,9 @@
+package com.github.spigotbasics.common
+
+data class SimpleLocation(
+    val world: String,
+    val x: Double,
+    val y: Double,
+    val z: Double,
+    val yaw: Float,
+    val pitch: Float)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,9 +6,12 @@ plugins {
     id("com.github.johnrengelman.shadow")
 }
 
+// api            = shaded, exposed to modules
+// apiCompileOnly = not shaded, exposed to modules
+// implementation = shaded, internal use only
+// compileOnly    = not shaded, internal use only
+//
 dependencies {
-    api(libs.gson)
-    testImplementation(libs.gson)
     implementation(libs.hikari)
     implementation(libs.adventure.api)
     implementation(libs.adventure.bukkit)
@@ -16,8 +19,11 @@ dependencies {
     implementation(libs.adventure.text.serializer.legacy)
     implementation(libs.paperlib)
     implementation(libs.folialib)
+    compileOnly(libs.placeholderapi)
     api(project(":common"))
     api(project(":pipe:facade"))
+    testImplementation(libs.gson)
+    api(libs.gson)
 
 
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -38,7 +38,7 @@ tasks.processResources {
 tasks.register("deployDocs", Exec::class) {
     dependsOn("dokkaHtml", "dokkaJavadoc")
 
-    group = "documentation"
+    group = "basics"
 
     doFirst {
         // Access the build directory properly to avoid deprecation warnings

--- a/core/src/main/kotlin/com/github/spigotbasics/core/Basics.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/Basics.kt
@@ -1,0 +1,82 @@
+package com.github.spigotbasics.core
+
+/**
+ * The Basics core, this is the Basics equivalent of the [org.bukkit.Bukkit] class
+ */
+object Basics {
+    private lateinit var basics: BasicsPlugin
+
+    /**
+     * Sets the plugin instance
+     *
+     * @param plugin The plugin instance
+     */
+    fun setPlugin(plugin: BasicsPlugin) {
+        if(::basics.isInitialized) throw IllegalStateException("Plugin already set")
+        this.basics = plugin
+    }
+
+    /**
+     * Gets the Basics plugin instance
+     *
+     * @return The Basics plugin instance
+     */
+    val plugin get() = basics
+
+    /**
+     * Provides MiniMessage audiences
+     */
+    val audienceProvider get() = basics.audienceProvider
+
+    /**
+     * Facade to uniformly access Spigot and Paper specific features.
+     */
+    val facade get() = basics.facade
+
+    /**
+     * The folder where the plugin's modules are stored.
+     */
+    val moduleFolder get() = basics.moduleFolder
+
+    /**
+     * Manager responsible for handling the various modules of the plugin.
+     */
+    val moduleManager get() = basics.moduleManager
+
+    /**
+     * Factory for creating and getting tag resolvers for MiniMessage
+     */
+    val tagResolverFactory get() = basics.tagResolverFactory
+
+    /**
+     * Message factory
+     */
+    val messageFactory get() = basics.messageFactory
+
+    /**
+     * Manager for handling configuration and message files
+     */
+    val coreConfigManager get() = basics.coreConfigManager
+
+    /**
+     * Messages used by the plugin itself or by more than one module.
+     */
+    val messages get() = basics.messages
+
+    /**
+     * Storage manager
+     */
+    val storageManager get() = basics.storageManager
+
+    /**
+     * Cache to lookup Names <> UUIDs
+     */
+    val corePlayerData get() = basics.corePlayerData
+
+    /**
+     * Reloads the core configuration settings of the plugin.
+     */
+    fun reloadCoreConfig() {
+        basics.reloadCoreConfig()
+    }
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
@@ -6,6 +6,7 @@ import com.github.spigotbasics.core.messages.AudienceProvider
 import com.github.spigotbasics.core.messages.MessageFactory
 import com.github.spigotbasics.core.messages.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
+import com.github.spigotbasics.core.playerdata.PlayerUUIDCache
 import com.github.spigotbasics.core.storage.StorageManager
 import com.github.spigotbasics.pipe.SpigotPaperFacade
 import org.bukkit.plugin.Plugin
@@ -54,6 +55,8 @@ interface BasicsPlugin: Plugin {
      * Storage manager
      */
     val storageManager: StorageManager
+
+    val playerUUIDCache: PlayerUUIDCache
 
     /**
      * Reloads the core configuration settings of the plugin.

--- a/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
@@ -13,12 +13,18 @@ import org.bukkit.plugin.Plugin
 import java.io.File
 
 /**
- * Represents the Basics Bukkit Plugin instance.
+ * Represents the Basics Bukkit Plugin instance - this is equivalent to the Bukkit [org.bukkit.Server] class.
  */
 interface BasicsPlugin: Plugin {
 
+    /**
+     * Provides MiniMessage audiences
+     */
     val audienceProvider: AudienceProvider
 
+    /**
+     * Facade to uniformly access Spigot and Paper specific features.
+     */
     val facade: SpigotPaperFacade
 
     /**

--- a/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
@@ -6,7 +6,7 @@ import com.github.spigotbasics.core.messages.AudienceProvider
 import com.github.spigotbasics.core.messages.MessageFactory
 import com.github.spigotbasics.core.messages.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
-import com.github.spigotbasics.core.playerdata.PlayerUUIDCache
+import com.github.spigotbasics.core.playerdata.CorePlayerData
 import com.github.spigotbasics.core.storage.StorageManager
 import com.github.spigotbasics.pipe.SpigotPaperFacade
 import org.bukkit.plugin.Plugin
@@ -56,7 +56,10 @@ interface BasicsPlugin: Plugin {
      */
     val storageManager: StorageManager
 
-    val playerUUIDCache: PlayerUUIDCache
+    /**
+     * Cache to lookup Names <> UUIDs
+     */
+    val corePlayerData: CorePlayerData
 
     /**
      * Reloads the core configuration settings of the plugin.

--- a/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/BasicsPlugin.kt
@@ -4,7 +4,7 @@ import com.github.spigotbasics.core.config.CoreConfigManager
 import com.github.spigotbasics.core.messages.CoreMessages
 import com.github.spigotbasics.core.messages.AudienceProvider
 import com.github.spigotbasics.core.messages.MessageFactory
-import com.github.spigotbasics.core.messages.TagResolverFactory
+import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
 import com.github.spigotbasics.core.playerdata.CorePlayerData
 import com.github.spigotbasics.core.storage.StorageManager

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
@@ -4,18 +4,14 @@ import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.BasicsModule
 import org.bukkit.permissions.Permission
 
-class BasicsCommandBuilder(private val module: BasicsModule) {
+class BasicsCommandBuilder(private val module: BasicsModule, private val name: String, private val permission: Permission) {
 
-    private var name: String? = null
-    private var permission: Permission? = null
     private var permissionMessage: Message = module.plugin.messages.noPermission
     private var description: String? = null
     private var usage: String? = null
     private var aliases: List<String> = emptyList()
     private var executor: BasicsCommandExecutor? = null
 
-    fun name(name: String) = apply { this.name = name }
-    fun permission(permission: Permission) = apply { this.permission = permission }
     fun description(description: String) = apply { this.description = description }
     fun usage(usage: String) = apply { this.usage = usage }
     fun permissionMessage(permissionMessage: Message) = apply { this.permissionMessage = permissionMessage }
@@ -38,8 +34,8 @@ class BasicsCommandBuilder(private val module: BasicsModule) {
 
     private fun build(): BasicsCommand {
         val info = CommandInfo(
-            name = name ?: error("Name must be set"),
-            permission = permission ?: error("Permission must be set"),
+            name = name,
+            permission = permission,
             permissionMessage = permissionMessage,
             description = description,
             usage = usage,

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandManager.kt
@@ -3,6 +3,11 @@ package com.github.spigotbasics.core.command
 import org.bukkit.Bukkit
 import org.bukkit.command.SimpleCommandMap
 
+/**
+ * Responsible for registering and keeping track of commands.
+ *
+ * @property serverCommandMap The server command map
+ */
 class BasicsCommandManager(private val serverCommandMap: SimpleCommandMap) {
 
     private val registeredCommands: MutableList<BasicsCommand> = mutableListOf()
@@ -15,7 +20,6 @@ class BasicsCommandManager(private val serverCommandMap: SimpleCommandMap) {
     }
 
     fun unregisterAll() {
-        // TODO: SimpleCommandMap uses an unmodifiable collection
         registeredCommands.toList().forEach { command ->
             unregisterCommand(command, false)
         }
@@ -31,7 +35,6 @@ class BasicsCommandManager(private val serverCommandMap: SimpleCommandMap) {
     }
 
     fun unregisterCommand(command: BasicsCommand, update: Boolean = true) {
-        //TODO("SimpleCommandMap uses an unmodifiable collection")
         registeredCommands -= command
         removeFromServerCommandMap(command)
         if (update) {
@@ -50,7 +53,6 @@ class BasicsCommandManager(private val serverCommandMap: SimpleCommandMap) {
         if(!success) {
             serverCommandMap.commands.forEach { existing ->
                 if(existing.name == command.name) {
-                    //serverCommandMap.commands.remove(existing)
                     if(existing is BasicsCommand) {
                         existing.replaceCommand(command)
                     }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Contains classes related to commands.
+ */
+package com.github.spigotbasics.core.command

--- a/core/src/main/kotlin/com/github/spigotbasics/core/config/CoreConfigManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/config/CoreConfigManager.kt
@@ -4,8 +4,7 @@ import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.BasicsPlugin
 import com.github.spigotbasics.core.SafeResourceGetter
 import com.github.spigotbasics.core.messages.MessageFactory
-import com.github.spigotbasics.core.messages.TagResolverFactory
-import com.github.spigotbasics.core.module.InvalidModuleException
+import com.github.spigotbasics.core.exceptions.InvalidModuleException
 import org.bukkit.configuration.InvalidConfigurationException
 import org.bukkit.configuration.file.YamlConfiguration
 import java.io.File

--- a/core/src/main/kotlin/com/github/spigotbasics/core/config/FixClassLoadingConfig.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/config/FixClassLoadingConfig.kt
@@ -1,0 +1,37 @@
+package com.github.spigotbasics.core.config
+
+import com.github.spigotbasics.core.BasicsPlugin
+import com.github.spigotbasics.core.logger.BasicsLoggerFactory
+import java.io.File
+
+class FixClassLoadingConfig(plugin: BasicsPlugin, file: File) : SavedConfig(plugin, file) {
+
+    private val logger = BasicsLoggerFactory.getCoreLogger(this::class)
+
+    val setEnabledDuringOnDisable
+        get() = getBooleanAndLog("set-enabled-during-ondisable")
+
+    val abuseClassesList
+        get() = getStringList("abuse-classes.others")
+
+    val abuseClassBasicsModule
+        get() = getBooleanAndLog("abuse-classes.BasicsModule")
+
+    val abuseClassAbstractBasicsModule
+        get() = getBooleanAndLog("abuse-classes.AbstractBasicsModule")
+
+    val abuseClassModuleManager
+        get() = getBooleanAndLog("abuse-classes.ModuleManager")
+
+    val callIteratorOnEmptyList
+        get() = getBooleanAndLog("call-iterator-on-empty-list")
+
+    private fun getBooleanAndLog(key: String): Boolean {
+        val value = getBoolean(key)
+        if(!value) {
+            logger.warning("$key is set to false")
+        }
+        return value
+    }
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/config/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/config/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Configuration classes.
+ */
+package com.github.spigotbasics.core.config

--- a/core/src/main/kotlin/com/github/spigotbasics/core/event/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/event/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Classes related to the module's event system.
+ */
+package com.github.spigotbasics.core.event

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/BasicsStorageAccessException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/BasicsStorageAccessException.kt
@@ -1,4 +1,4 @@
-package com.github.spigotbasics.core.storage
+package com.github.spigotbasics.core.exceptions
 
 import java.io.IOException
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/BasicsStorageInitializeException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/BasicsStorageInitializeException.kt
@@ -1,4 +1,4 @@
-package com.github.spigotbasics.core.storage
+package com.github.spigotbasics.core.exceptions
 
 import java.io.IOException
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/ForbiddenFruitException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/ForbiddenFruitException.kt
@@ -1,5 +1,6 @@
-package com.github.spigotbasics.core.module
+package com.github.spigotbasics.core.exceptions
 
+import com.github.spigotbasics.core.module.BasicsModule
 import com.github.spigotbasics.core.scheduler.BasicsScheduler
 import kotlin.reflect.KProperty1
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/InvalidModuleException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/InvalidModuleException.kt
@@ -1,4 +1,4 @@
-package com.github.spigotbasics.core.module
+package com.github.spigotbasics.core.exceptions
 
 import java.io.IOException
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/ModuleAlreadyLoadedException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/ModuleAlreadyLoadedException.kt
@@ -1,4 +1,6 @@
-package com.github.spigotbasics.core.module
+package com.github.spigotbasics.core.exceptions
+
+import com.github.spigotbasics.core.module.ModuleInfo
 
 class ModuleAlreadyLoadedException(moduleInfo: ModuleInfo): Exception("Module ${moduleInfo.name} is already loaded") {
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/WorldNotLoadedException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/WorldNotLoadedException.kt
@@ -1,0 +1,8 @@
+package com.github.spigotbasics.core.exceptions
+
+import org.bukkit.Location
+
+class WorldNotLoadedException : IllegalStateException {
+    constructor(worldName: String) : super("Given world '$worldName' is not loaded")
+    constructor(location: Location) : super("World of location '$location' is not loaded")
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/exceptions/package.kt
@@ -1,0 +1,3 @@
+/**
+ * Custom exceptions
+ */

--- a/core/src/main/kotlin/com/github/spigotbasics/core/extensions/_Location.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/extensions/_Location.kt
@@ -1,0 +1,18 @@
+package com.github.spigotbasics.core.extensions
+
+import com.github.spigotbasics.common.SimpleLocation
+import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
+import org.bukkit.Bukkit
+import org.bukkit.Location
+
+@Throws(WorldNotLoadedException::class)
+fun Location.toSimpleLocation(): SimpleLocation {
+    val world = world ?: throw WorldNotLoadedException(this)
+    return SimpleLocation(world.name, x, y, z, yaw, pitch)
+}
+
+@Throws(WorldNotLoadedException::class)
+fun SimpleLocation.toLocation(): Location {
+    val world = Bukkit.getWorld(this.world) ?: throw WorldNotLoadedException(this.world)
+    return Location(world, x, y, z, yaw, pitch)
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/extensions/_Location.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/extensions/_Location.kt
@@ -1,18 +1,7 @@
 package com.github.spigotbasics.core.extensions
 
-import com.github.spigotbasics.common.SimpleLocation
+import com.github.spigotbasics.core.model.SimpleLocation
 import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
 import org.bukkit.Bukkit
 import org.bukkit.Location
 
-@Throws(WorldNotLoadedException::class)
-fun Location.toSimpleLocation(): SimpleLocation {
-    val world = world ?: throw WorldNotLoadedException(this)
-    return SimpleLocation(world.name, x, y, z, yaw, pitch)
-}
-
-@Throws(WorldNotLoadedException::class)
-fun SimpleLocation.toLocation(): Location {
-    val world = Bukkit.getWorld(this.world) ?: throw WorldNotLoadedException(this.world)
-    return Location(world, x, y, z, yaw, pitch)
-}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/extensions/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/extensions/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Generic Extension methods.
+ */
+package com.github.spigotbasics.core.extensions

--- a/core/src/main/kotlin/com/github/spigotbasics/core/listener/PlayerDataListener.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/listener/PlayerDataListener.kt
@@ -98,7 +98,7 @@ class PlayerDataListener(
 
         if (future == null) {
             event.player.kickPlayer(messages.failedToLoadDataOnJoin.toLegacy() + " (Error: No future found)")
-            logger.severe("Player ${event.player.name} made it to PlayerJoinEvent despite not having any data loader (No future found), kicking them now.")
+            logger.severe("Player ${event.player.name} made it to PlayerJoinEvent despite not having any data loaded (No future found), kicking them now.")
             return
         }
         if (!future.isDone) {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/listener/PlayerDataListener.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/listener/PlayerDataListener.kt
@@ -26,7 +26,7 @@ class PlayerDataListener(
 
     private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     fun onPlayerLogin(event: AsyncPlayerPreLoginEvent) {
         if (event.loginResult != AsyncPlayerPreLoginEvent.Result.ALLOWED) {
             return

--- a/core/src/main/kotlin/com/github/spigotbasics/core/logger/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/logger/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Logging utilities.
+ */
+package com.github.spigotbasics.core.logger

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/CoreMessages.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/CoreMessages.kt
@@ -16,8 +16,10 @@ class CoreMessages(plugin: BasicsPlugin, file: File) : SavedConfig(plugin, file)
     val commandNotFromConsole get() = getMessage("command-not-from-console")
     val mustSpecifyPlayerFromConsole get() = getMessage("must-specify-player-from-console")
     val commandModuleDisabled get() = getMessage("command-module-disabled")
+    val failedToLoadDataOnJoin get() = getMessage("failed-to-load-data-on-join")
     fun noPermission(permission: Permission) = getMessage("no-permission").tags("permission" to permission.name)
     fun unknownOption(option: String) = getMessage("unknown-option").tagUnparsed("option", option)
     fun invalidArgument(argument: String) = getMessage("invalid-argument").tagUnparsed("argument", argument)
     fun playerNotFound(name: String) = getMessage("player-not-found").tagUnparsed("argument", name)
+
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/Message.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/Message.kt
@@ -1,5 +1,6 @@
 package com.github.spigotbasics.core.messages
 
+import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 import com.github.spigotbasics.pipe.SerializedMiniMessage
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.JoinConfiguration

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
@@ -1,5 +1,7 @@
 package com.github.spigotbasics.core.messages
 
+import com.github.spigotbasics.core.messages.tags.TagResolverFactory
+
 private const val UNPARSED = "__unparsed__"
 private const val UNPARSED_TAG = "<$UNPARSED>"
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Message and text related classes.
+ */
+package com.github.spigotbasics.core.messages

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTag.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTag.kt
@@ -1,0 +1,83 @@
+package com.github.spigotbasics.core.messages.tags
+
+import net.kyori.adventure.text.format.StyleBuilderApplicable
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import org.bukkit.configuration.ConfigurationSection
+
+data class CustomTag(val name: String, val value: String, val type: CustomTagType) {
+    companion object {
+        val defaultTagType = CustomTagType.PARSED
+
+        val hexRegex = Regex("#[0-9a-fA-F]{6}")
+
+        /**
+         * Parses a tag from the given... whatever it is.
+         *
+         * @param key The tag key
+         * @param value The tag value
+         * @return The parsed tag
+         */
+        fun parse(key: String, value: Any): CustomTag {
+            @Suppress("UNCHECKED_CAST")
+            return when (value) {
+                is String -> fromString(key, value)
+                is ConfigurationSection -> fromSection(key, value)
+                is Map<*, *> -> fromMap(key, value as Map<String, Any?>)
+                else -> throw IllegalArgumentException("Invalid tag format for tag '$key': $value")
+            }
+        }
+
+        /**
+         * Parses a tag from the given string
+         *
+         * @param key The tag key
+         * @param value The tag value
+         */
+        fun fromString(key: String, value: String) = CustomTag(key, value, defaultTagType)
+
+        /**
+         * Parses a tag from the given configuration section
+         *
+         * @param key The tag key
+         * @param value The tag value
+         */
+        fun fromSection(key: String, value: ConfigurationSection) = fromMap(key, value.getValues(false))
+
+        /**
+         * Parses a tag from the given map
+         *
+         * @param key The tag key
+         * @param map The tag value
+         * @return The parsed tag
+         */
+        fun fromMap(key: String, map: Map<String, Any?>): CustomTag {
+            val type = (map["type"] as? String)?.let { CustomTagType.fromString(it) } ?: defaultTagType
+            val value = when (map["value"]) {
+                is String -> map["value"] as String
+                is List<*> -> (map["value"] as List<*>).joinToString("\n")
+                else -> throw IllegalArgumentException("Invalid value for tag '$key': ${map["value"]}")
+            }
+            return CustomTag(key, value, type)
+        }
+
+    }
+
+    fun toTagResolver(): TagResolver {
+        return when(type) {
+            CustomTagType.PARSED -> Placeholder.parsed(name, value)
+            CustomTagType.UNPARSED -> Placeholder.unparsed(name, value)
+            CustomTagType.COLOR -> createColorTagResolver()
+        }
+    }
+
+    private fun createColorTagResolver(): TagResolver {
+        if(hexRegex.matches(value)) {
+            val color = TextColor.fromHexString(value)!!
+            return Placeholder.styling(name, color)
+        } else {
+            throw IllegalArgumentException("Invalid hex color for tag '$name': $value - must be in format #RRGGBB")
+        }
+    }
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTag.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTag.kt
@@ -69,6 +69,7 @@ data class CustomTag(val name: String, val value: String, val type: CustomTagTyp
             CustomTagType.PARSED -> Placeholder.parsed(name, value)
             CustomTagType.UNPARSED -> Placeholder.unparsed(name, value)
             CustomTagType.COLOR -> createColorTagResolver()
+            //CustomTagType.PLACEHOLDER -> createPlaceholderApiTagResolver()
         }
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTagType.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTagType.kt
@@ -1,0 +1,41 @@
+package com.github.spigotbasics.core.messages.tags
+
+/**
+ * Represents the type of custom tag
+ */
+enum class CustomTagType {
+    /**
+     * Parsed tags can contain further tags
+     */
+    PARSED,
+
+    /**
+     * Unparsed tags are like plain text
+     */
+    UNPARSED,
+
+    /**
+     * Color codes that can be used with <cute-pink>opening and closing tags</cute-pink>
+     */
+    COLOR;
+
+    companion object {
+
+        /**
+         * Returns the tag type from the given string, case-insensitive
+         *
+         * @param string The string to be converted
+         * @return The tag type
+         * @throws IllegalArgumentException If the string is not a valid tag type
+         */
+        @Throws(IllegalArgumentException::class)
+        fun fromString(string: String): CustomTagType {
+            return when(string.uppercase()) {
+                "PARSED" -> PARSED
+                "UNPARSED" -> UNPARSED
+                "COLOR" -> COLOR
+                else -> throw IllegalArgumentException("Unknown tag type '$string' - valid types are ${entries.joinToString()}")
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTagType.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/CustomTagType.kt
@@ -17,7 +17,14 @@ enum class CustomTagType {
     /**
      * Color codes that can be used with <cute-pink>opening and closing tags</cute-pink>
      */
-    COLOR;
+    COLOR,
+
+//    /**
+//     * Placeholder tags are placeholders from PlaceholderAPI
+//     */
+//    PLACEHOLDER;
+
+    ;
 
     companion object {
 
@@ -34,6 +41,7 @@ enum class CustomTagType {
                 "PARSED" -> PARSED
                 "UNPARSED" -> UNPARSED
                 "COLOR" -> COLOR
+                //"PAPI", "PLACEHOLDER", "PLACEHOLDERAPI" -> PLACEHOLDER
                 else -> throw IllegalArgumentException("Unknown tag type '$string' - valid types are ${entries.joinToString()}")
             }
         }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/PlaceholderAPITagFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/PlaceholderAPITagFactory.kt
@@ -1,0 +1,21 @@
+package com.github.spigotbasics.core.messages.tags
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.minimessage.Context
+import net.kyori.adventure.text.minimessage.tag.Tag
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+
+object PlaceholderAPITagFactory {
+
+    fun getPapiTagResolver(): TagResolver {
+        return TagResolver.resolver("click-by-version") { args, context ->
+            val version = args.popOr("version expected").value()
+            Tag.styling(ClickEvent.openUrl("https://jd.advntr.dev/api/$version/"))
+        }
+
+    }
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/PlaceholderAPITagFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/PlaceholderAPITagFactory.kt
@@ -1,21 +1,38 @@
 package com.github.spigotbasics.core.messages.tags
 
+import me.clip.placeholderapi.PlaceholderAPI
 import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.TextComponent
-import net.kyori.adventure.text.event.ClickEvent
-import net.kyori.adventure.text.minimessage.Context
 import net.kyori.adventure.text.minimessage.tag.Tag
-import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
+import org.bukkit.entity.Player
 
 object PlaceholderAPITagFactory {
 
-    fun getPapiTagResolver(): TagResolver {
-        return TagResolver.resolver("click-by-version") { args, context ->
-            val version = args.popOr("version expected").value()
-            Tag.styling(ClickEvent.openUrl("https://jd.advntr.dev/api/$version/"))
+    val nonPlayerPapi = createNonPlayerPapi()
+
+    private fun createNonPlayerPapi(): TagResolver {
+        return TagResolver.resolver("papi") { args, _ ->
+            val content = args.popOr("string expected").value()
+            Tag.inserting(Component.text().content(replacePlaceholders(content)))
         }
 
+    }
+
+    fun playerPapi(player: Player): TagResolver {
+        return TagResolver.resolver("papi") { args, _ ->
+            val content = args.popOr("string expected").value()
+            Tag.inserting(Component.text().content(replacePlaceholders(content, player)))
+        }
+    }
+
+    fun replacePlaceholders(message: String, player: OfflinePlayer? = null): String {
+        if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            return PlaceholderAPI.setPlaceholders(player, message)
+        } else {
+            return message
+        }
     }
 
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
@@ -33,7 +33,8 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
         return listOf(
             Placeholder.parsed("player-name", player.name),
             Placeholder.parsed("player-name-genitive-suffix", player.name.genitiveSuffix()),
-            createDisplayNameTagResolver(player)
+            createDisplayNameTagResolver(player),
+            PlaceholderAPITagFactory.getPapiTagResolver()
         )
     }
 
@@ -71,12 +72,6 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
      */
     fun loadCustomTags(yaml: YamlConfiguration) {
         try {
-//            val simplePlaceholders = yaml.getValues(true).mapValues {
-//                val value: String = it.value?.toString() ?: ""
-//                return@mapValues value
-//            }
-
-
             customTagResolvers = yaml.getValues(false).mapNotNull { (key, value) ->
                 try {
                     val tag = CustomTag.parse(key, value)
@@ -87,10 +82,7 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
                 }
             }.toList()
 
-            //customTagsMap = map
-            //customParsedTagResolvers = simplePlaceholders.map { Placeholder.parsed(it.key, it.value) }
             defaultNonPlayerTagResolverList = createDefaultNonPlayerTagResolverList()
-
         } catch (e: Exception) {
             logger.log(Level.SEVERE, "Failed to load custom tags", e)
         }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
@@ -1,4 +1,4 @@
-package com.github.spigotbasics.core.messages
+package com.github.spigotbasics.core.messages.tags
 
 import com.github.spigotbasics.common.Either
 import com.github.spigotbasics.core.extensions.genitiveSuffix
@@ -11,22 +11,21 @@ import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.entity.Player
 import java.util.logging.Level
 
-// TODO: Add PlaceholderAPI <papi:...> tag
+/**
+ * Allows easy construction of custom tag resolvers for MiniMessage
+ */
 class TagResolverFactory(private val facade: SpigotPaperFacade) {
 
     private val logger = BasicsLoggerFactory.getCoreLogger(TagResolverFactory::class)
+    private val miniMessage = MiniMessage.miniMessage()
 
-    private var customTagsMap: Map<String, String> = emptyMap()
-    private var customParsedTagResolvers: List<TagResolver> =
-        listOf() // = customTagsMap.map { Placeholder.parsed(it.key, it.value) }
-    private var defaultNonPlayerTagResolverList: List<TagResolver> =
-        listOf(); // = createDefaultNonPlayerTagResolverList()
-
-    private val mini = MiniMessage.miniMessage()
+    //private var customTagsMap: Map<String, String> = emptyMap()
+    private var customTagResolvers: List<TagResolver> = listOf()
+    private var defaultNonPlayerTagResolverList: List<TagResolver> = listOf();
 
     private fun createDefaultNonPlayerTagResolverList(): List<TagResolver> {
-        return listOf( // TODO: Add static placeholders
-            Placeholder.parsed("basics", "<bold>Basics Plugin</bold>")
+        return listOf(
+            //Placeholder.parsed("basics", "<bold>Basics Plugin</bold>")
         )
     }
 
@@ -41,7 +40,7 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
     private fun createDisplayNameTagResolver(player: Player): TagResolver {
         val result = facade.getDisplayName(player)
         return if (result is Either.Right) {
-            Placeholder.component("player-display-name", mini.deserialize(result.value.value))
+            Placeholder.component("player-display-name", miniMessage.deserialize(result.value.value))
         } else if (result is Either.Left) {
             Placeholder.unparsed("player-display-name", result.value)
         } else {
@@ -49,28 +48,47 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
         }
     }
 
+    /**
+     * Gets all applicable tag resolvers
+     *
+     * @param player The player to be used for player-related placeholders
+     * @return List of all tag resolvers
+     */
     fun getTagResolvers(player: Player? = null): List<TagResolver> {
         val list = mutableListOf<TagResolver>()
         list.addAll(defaultNonPlayerTagResolverList) // TODO:
-        list.addAll(customParsedTagResolvers) // TODO: Cache these two
+        list.addAll(customTagResolvers) // TODO: Cache these two
         if (player != null) {
             list.addAll(createDefaultPlayerTagResolverList(player))
         }
         return list
     }
 
+    /**
+     * Loads all custom tags from the given YAML configuration
+     *
+     * @param yaml The YAML configuration
+     */
     fun loadCustomTags(yaml: YamlConfiguration) {
         try {
-            val map = yaml.getValues(true).mapValues {
-                val value: String = it.value?.toString() ?: ""
-                //println("tag <${it.key}> = $value")
-
-                return@mapValues value
-            }
+//            val simplePlaceholders = yaml.getValues(true).mapValues {
+//                val value: String = it.value?.toString() ?: ""
+//                return@mapValues value
+//            }
 
 
-            customTagsMap = map
-            customParsedTagResolvers = customTagsMap.map { Placeholder.parsed(it.key, it.value) }
+            customTagResolvers = yaml.getValues(false).mapNotNull { (key, value) ->
+                try {
+                    val tag = CustomTag.parse(key, value)
+                    return@mapNotNull tag.toTagResolver()
+                } catch (e: Exception) {
+                    e.message?.let { logger.warning(it) } ?: logger.warning("Failed to parse tag '$key'")
+                    return@mapNotNull null
+                }
+            }.toList()
+
+            //customTagsMap = map
+            //customParsedTagResolvers = simplePlaceholders.map { Placeholder.parsed(it.key, it.value) }
             defaultNonPlayerTagResolverList = createDefaultNonPlayerTagResolverList()
 
         } catch (e: Exception) {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/tags/TagResolverFactory.kt
@@ -9,6 +9,10 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import java.util.*
 import java.util.logging.Level
 
 /**
@@ -19,22 +23,22 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
     private val logger = BasicsLoggerFactory.getCoreLogger(TagResolverFactory::class)
     private val miniMessage = MiniMessage.miniMessage()
 
-    //private var customTagsMap: Map<String, String> = emptyMap()
-    private var customTagResolvers: List<TagResolver> = listOf()
-    private var defaultNonPlayerTagResolverList: List<TagResolver> = listOf();
+    private val nonPlayerResolvers = mutableListOf<TagResolver>()
+    private val playerResolvers = mutableMapOf<UUID, List<TagResolver>>()
 
-    private fun createDefaultNonPlayerTagResolverList(): List<TagResolver> {
+    private fun createDefaultPlaceholders(): List<TagResolver> {
         return listOf(
-            //Placeholder.parsed("basics", "<bold>Basics Plugin</bold>")
+            // Clashes with per-player PAPI, so only add this if requesting TagResolvers for non-player
+            // PlaceholderAPITagFactory.nonPlayerPapi
         )
     }
 
-    private fun createDefaultPlayerTagResolverList(player: Player): List<TagResolver> {
+    private fun createDefaultPlaceholdersForPlayer(player: Player): List<TagResolver> {
         return listOf(
             Placeholder.parsed("player-name", player.name),
             Placeholder.parsed("player-name-genitive-suffix", player.name.genitiveSuffix()),
             createDisplayNameTagResolver(player),
-            PlaceholderAPITagFactory.getPapiTagResolver()
+            PlaceholderAPITagFactory.playerPapi(player)
         )
     }
 
@@ -50,29 +54,33 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
     }
 
     /**
-     * Gets all applicable tag resolvers
+     * Gets all applicable tag resolvers, which are:
+     *
+     * - The default non-player placeholders
+     * - The custom tag resolvers (custom-tags.yml)
+     * - The player-specific placeholders (player-name, display-name, ...), if a player is provided
+     * - The player-specific PAPI Resolver, if a player is provided
+     * - The non-player PAPI Resolver, if a player is not provided
      *
      * @param player The player to be used for player-related placeholders
      * @return List of all tag resolvers
      */
     fun getTagResolvers(player: Player? = null): List<TagResolver> {
-        val list = mutableListOf<TagResolver>()
-        list.addAll(defaultNonPlayerTagResolverList) // TODO:
-        list.addAll(customTagResolvers) // TODO: Cache these two
-        if (player != null) {
-            list.addAll(createDefaultPlayerTagResolverList(player))
+        return if (player != null) {
+            getPlayerResolvers(player)
+        } else {
+            nonPlayerResolvers + PlaceholderAPITagFactory.nonPlayerPapi
         }
-        return list
     }
 
     /**
-     * Loads all custom tags from the given YAML configuration
+     * Loads and caches all TagResolvers, including default, custom and player-specific resolvers
      *
-     * @param yaml The YAML configuration
+     * @param customTagsConfig Configuration for custom tags
      */
-    fun loadCustomTags(yaml: YamlConfiguration) {
+    fun loadAndCacheAllTagResolvers(customTagsConfig: YamlConfiguration) { // TODO: Use getConfig(...) instead of passing a YamlConfiguration
         try {
-            customTagResolvers = yaml.getValues(false).mapNotNull { (key, value) ->
+            val customTagResolvers = customTagsConfig.getValues(false).mapNotNull { (key, value) ->
                 try {
                     val tag = CustomTag.parse(key, value)
                     return@mapNotNull tag.toTagResolver()
@@ -82,9 +90,49 @@ class TagResolverFactory(private val facade: SpigotPaperFacade) {
                 }
             }.toList()
 
-            defaultNonPlayerTagResolverList = createDefaultNonPlayerTagResolverList()
+            nonPlayerResolvers.clear()
+            nonPlayerResolvers.addAll(customTagResolvers)
+            nonPlayerResolvers.addAll(createDefaultPlaceholders())
+
+            playerResolvers.clear()
         } catch (e: Exception) {
             logger.log(Level.SEVERE, "Failed to load custom tags", e)
+        }
+    }
+
+    /**
+     * Listens to player join and quit events to manage the list of player-specific tag resolvers
+     */
+    inner class Listener : org.bukkit.event.Listener {
+        @EventHandler
+        fun onJoin(event: PlayerJoinEvent) {
+            getPlayerResolvers(event.player)
+        }
+
+        @EventHandler
+        fun onQuit(event: PlayerQuitEvent) {
+            playerResolvers.remove(event.player.uniqueId)
+        }
+    }
+
+    /**
+     * Returns a list of ALL available TagResolvers for this player, which are:
+     * - The default non-player placeholders
+     * - The custom tag resolvers (custom-tags.yml)
+     * - The player-specific placeholders (player-name, display-name, ...)
+     * - The player-specific PAPI placeholders
+     *
+     * The list is cached for each player, or generated if not cached.
+     *
+     * @param player The player to get the resolvers for
+     * @return The list of resolvers
+     */
+    private fun getPlayerResolvers(player: Player): List<TagResolver> {
+        return playerResolvers.computeIfAbsent(player.uniqueId) {
+            val list = mutableListOf<TagResolver>()
+            list.addAll(createDefaultPlaceholdersForPlayer(player))
+            list.addAll(nonPlayerResolvers)
+            return@computeIfAbsent list
         }
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/model/SimpleLocation.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/model/SimpleLocation.kt
@@ -1,0 +1,47 @@
+package com.github.spigotbasics.core.model
+
+import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
+import org.bukkit.Bukkit
+import org.bukkit.Location
+
+/**
+ * Represents a [Location] that references a [org.bukkit.World] by name.
+ *
+ * @property world The name of the world.
+ * @property x The x coordinate.
+ * @property y The y coordinate.
+ * @property z The z coordinate.
+ * @property yaw The yaw.
+ * @property pitch The pitch.
+ */
+data class SimpleLocation(
+    val world: String,
+    val x: Double,
+    val y: Double,
+    val z: Double,
+    val yaw: Float,
+    val pitch: Float)
+
+/**
+ * Turns a [Location] into a [SimpleLocation].
+ *
+ * @return The [SimpleLocation] representation of the [Location].
+ * @throws WorldNotLoadedException If the Location returns a null world.
+ */
+@Throws(WorldNotLoadedException::class)
+fun Location.toSimpleLocation(): SimpleLocation {
+    val world = world ?: throw WorldNotLoadedException(this)
+    return SimpleLocation(world.name, x, y, z, yaw, pitch)
+}
+
+/**
+ * Turns a [SimpleLocation] into a [Location].
+ *
+ * @return The [Location] representation of the [SimpleLocation].
+ * @throws WorldNotLoadedException If the world is not loaded.
+ */
+@Throws(WorldNotLoadedException::class)
+fun SimpleLocation.toLocation(): Location {
+    val world = Bukkit.getWorld(this.world) ?: throw WorldNotLoadedException(this.world)
+    return Location(world, x, y, z, yaw, pitch)
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/model/package.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/model/package.kt
@@ -1,0 +1,4 @@
+/**
+ * Contains classes representing Minecraft objects, such as Locations.
+ */
+package com.github.spigotbasics.core.model

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/AbstractBasicsModule.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/AbstractBasicsModule.kt
@@ -1,5 +1,6 @@
 package com.github.spigotbasics.core.module
 
+import com.github.spigotbasics.core.BasicsPlugin
 import com.github.spigotbasics.core.command.BasicsCommandBuilder
 import com.github.spigotbasics.core.command.BasicsCommandManager
 import com.github.spigotbasics.core.config.ConfigName
@@ -15,6 +16,9 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 
+/**
+ * Represents the main class of a module. Extending classes require a public constructor that takes in a [ModuleInstantiationContext].
+ */
 abstract class AbstractBasicsModule(context: ModuleInstantiationContext) : BasicsModule {
 
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/AbstractBasicsModule.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/AbstractBasicsModule.kt
@@ -1,91 +1,46 @@
 package com.github.spigotbasics.core.module
 
+import com.github.spigotbasics.core.command.BasicsCommandBuilder
 import com.github.spigotbasics.core.command.BasicsCommandManager
 import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.config.SavedConfig
 import com.github.spigotbasics.core.event.BasicsEventBus
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import com.github.spigotbasics.core.permission.BasicsPermissionManager
 import com.github.spigotbasics.core.scheduler.BasicsScheduler
 import com.github.spigotbasics.core.storage.NamespacedStorage
+import org.bukkit.permissions.Permission
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 
 abstract class AbstractBasicsModule(context: ModuleInstantiationContext) : BasicsModule {
 
-    /**
-     * Module class loader
-     */
+
     final override val moduleClassLoader = context.classLoader
-
-    /**
-     * Module file
-     */
-    final override val moduleFile = context.file
-
-    /**
-     * Module info
-     */
+    final override val file = context.file
     final override val info = context.info
-
-    /**
-     * Logger for this module
-     */
     final override val logger = BasicsLoggerFactory.getModuleLogger(this)
-
-    /**
-     * Plugin instance
-     */
     final override val plugin = context.plugin
-
-    /**
-     * Event bus for registering events
-     */
     final override val eventBus = BasicsEventBus(context.plugin)
+    final override val config = getConfig(ConfigName.CONFIG)
+    final override val scheduler = BasicsScheduler(plugin)
+    final override val commandManager = BasicsCommandManager(plugin.facade.getCommandMap(plugin.server.pluginManager))
+    final override val messageFactory = plugin.messageFactory
+    final override val tagResolverFactory /*get()*/ = plugin.tagResolverFactory
+    final override val permissionManager = BasicsPermissionManager(logger)
 
-    /**
-     * Config
-     */
-    override var config = getConfig(ConfigName.CONFIG)
+    private val storages: MutableMap<String, NamespacedStorage> = mutableMapOf()
+
+    private var isEnabled = false
 
     override fun reloadConfig() {
         config.reload()
     }
 
-    /**
-     * Scheduler
-     */
-    override val scheduler = BasicsScheduler(plugin)
 
-    override val commandManager = BasicsCommandManager(plugin.facade.getCommandMap(plugin.server.pluginManager))
-
-    /**
-     * Message Factory
-     */
-    override val messageFactory = plugin.messageFactory
-
-    override val tagResolverFactory
-        get() = plugin.tagResolverFactory
-
-    override val permissionManager = BasicsPermissionManager(logger)
-
-    private val storages: MutableMap<String, NamespacedStorage> = mutableMapOf()
-
-    fun getConfig(configName: ConfigName/*, clazzToGetFrom: Class<*> = javaClass*/): SavedConfig =
-        getConfig(configName/*, clazzToGetFrom*/, SavedConfig::class.java)
-
-    fun <T : SavedConfig> getConfig(
-        configName: ConfigName/*, clazzToGetFrom: Class<*>*/,
-        configurationClass: Class<T>
-    ): T = plugin.coreConfigManager.getConfig(
-        configName.path,
-        getNamespacedResourceName(configName.path),
-        javaClass,
-        configurationClass
-    )
-
-    override fun createStorage(name: String?): NamespacedStorage {
+    final override fun createStorage(name: String?): NamespacedStorage {
         if (!isEnabled) {
             throw IllegalStateException("Cannot create storage while module is disabled")
         }
@@ -104,25 +59,7 @@ abstract class AbstractBasicsModule(context: ModuleInstantiationContext) : Basic
         return storage
     }
 
-    /**
-     * Get namespaced resource name. For `config.yml` this will simply be `<module-name>.yml`, for all other files it will be `<module-name>-<file-name>`.
-     *
-     * @param path Path to the resource
-     * @return Namespaced resource name
-     */
-    private fun getNamespacedResourceName(path: String): String {
-        var newPath = path
 
-        // Remove leading slash
-        if (path.startsWith("/")) {
-            newPath = path.substring(1)
-        }
-
-        // All other files are called <module-name>-<file-name>
-        return "${info.name}-$newPath"
-    }
-
-    private var isEnabled = false
     final override fun enable(reloadConfig: Boolean) {
         isEnabled = true
         if (reloadConfig) {
@@ -140,16 +77,53 @@ abstract class AbstractBasicsModule(context: ModuleInstantiationContext) : Basic
         return storageShutdownFuture
     }
 
-    private fun shutdownAllStorages(): CompletableFuture<Void?> =
-        CompletableFuture.allOf(*storages.values.map {
-            it.shutdown(10, TimeUnit.SECONDS).whenComplete { _, ex ->
-                if (ex != null) logger.log(Level.SEVERE, "Failed to shutdown storage ${it.namespace}", ex)
-                storages.remove(it.namespace)
-            }
-        }.toTypedArray())
+    private fun shutdownAllStorages(): CompletableFuture<Void?> = CompletableFuture.allOf(*storages.values.map {
+        it.shutdown(10, TimeUnit.SECONDS).whenComplete { _, ex ->
+            if (ex != null) logger.log(Level.SEVERE, "Failed to shutdown storage ${it.namespace}", ex)
+            storages.remove(it.namespace)
+        }
+    }.toTypedArray())
 
-    override fun isEnabled(): Boolean {
+    final override fun isEnabled(): Boolean {
         return isEnabled
+    }
+
+    final override fun loadAllOnlinePlayerData(): CompletableFuture<Void?> {
+        val futures = mutableListOf<CompletableFuture<Void?>>()
+        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
+            futures += loadPlayerData(player.uniqueId)
+        }
+        return CompletableFuture.allOf(*futures.toTypedArray())
+    }
+
+    private fun saveAllOnlinePlayerData(): CompletableFuture<Void?> {
+        val futures = mutableListOf<CompletableFuture<Void?>>()
+        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
+            futures += savePlayerData(player.uniqueId)
+        }
+        return CompletableFuture.allOf(*futures.toTypedArray())
+    }
+
+    final override fun saveAndForgetAllOnlinePlayerData(): CompletableFuture<Void?> {
+        val futures = mutableListOf<CompletableFuture<Void?>>()
+        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
+            // TODO: See comment below
+            futures += savePlayerData(player.uniqueId).whenComplete { _, _ -> // This was line 124 from below stacktrace
+                forgetPlayerData(player.uniqueId)
+            }
+        }
+        return CompletableFuture.allOf(*futures.toTypedArray())
+    }
+
+    final override fun getConfig(configName: ConfigName): SavedConfig = getConfig(configName, SavedConfig::class.java)
+
+    final override fun <T : SavedConfig> getConfig(configName: ConfigName, configurationClass: Class<T>): T =
+        plugin.coreConfigManager.getConfig(
+            configName.path, getNamespacedResourceName(configName.path), javaClass, configurationClass
+        )
+
+    final override fun createCommand(name: String, permission: Permission): BasicsCommandBuilder {
+        return BasicsCommandBuilder(this, name, permission)
     }
 
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/BasicsModule.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/BasicsModule.kt
@@ -3,15 +3,17 @@ package com.github.spigotbasics.core.module
 import com.github.spigotbasics.core.BasicsPlugin
 import com.github.spigotbasics.core.command.BasicsCommandBuilder
 import com.github.spigotbasics.core.command.BasicsCommandManager
+import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.config.SavedConfig
 import com.github.spigotbasics.core.event.BasicsEventBus
 import com.github.spigotbasics.core.logger.BasicsLogger
 import com.github.spigotbasics.core.messages.MessageFactory
-import com.github.spigotbasics.core.messages.TagResolverFactory
+import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 import com.github.spigotbasics.core.module.loader.ModuleJarClassLoader
 import com.github.spigotbasics.core.permission.BasicsPermissionManager
 import com.github.spigotbasics.core.scheduler.BasicsScheduler
 import com.github.spigotbasics.core.storage.NamespacedStorage
+import org.bukkit.permissions.Permission
 import java.io.File
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -23,9 +25,34 @@ import java.util.concurrent.CompletableFuture
  */
 interface BasicsModule {
 
+    // ----- Global instances -----
+
+    /**
+     * Basics instance
+     */
     val plugin: BasicsPlugin
+
+    /**
+     * The global Message Factory
+     */
+    val messageFactory: MessageFactory
+
+    /**
+     * The global Tag Resolver Factory
+     */
+    val tagResolverFactory: TagResolverFactory
+
+    // ----- Module instances -----
+
+    /**
+     * This module's .jar file
+     */
+    val file: File
+
+    /**
+     * This module's class loader
+     */
     val moduleClassLoader: ModuleJarClassLoader
-    val moduleFile: File
 
     /**
      * Info about this module
@@ -43,26 +70,21 @@ interface BasicsModule {
     val logger: BasicsLogger
 
     /**
-     * Modules scheduler
+     * This module's scheduler
      */
     val scheduler: BasicsScheduler
 
     /**
-     * Message Factory
-     */
-    val messageFactory: MessageFactory
-
-    /**
-     * Command manager
+     * This module's command manager
      */
     val commandManager: BasicsCommandManager
 
     /**
-     * Event bus for registering events
+     * This module's event bus
      */
     val eventBus: BasicsEventBus
 
-    val tagResolverFactory: TagResolverFactory
+
 
     val permissionManager: BasicsPermissionManager
 
@@ -70,29 +92,23 @@ interface BasicsModule {
      * Called when the module is enabled
      *
      */
-    fun onEnable() {
-
-    }
+    fun onEnable() = Unit
 
     /**
      * Called when the module is disabled
      *
      */
-    fun onDisable() {
-
-    }
+    fun onDisable() = Unit
 
     fun enable(reloadConfig: Boolean)
+
     fun disable(): CompletableFuture<Void?>
 
     fun isEnabled(): Boolean
 
-
     fun reloadConfig()
 
-    fun createCommand(): BasicsCommandBuilder {
-        return BasicsCommandBuilder(this)
-    }
+    fun createCommand(name: String, permission: Permission): BasicsCommandBuilder
 
     fun createStorage(name: String? = null): NamespacedStorage
 
@@ -102,63 +118,29 @@ interface BasicsModule {
 
     fun forgetPlayerData(uuid: UUID) = Unit
 
-    fun loadAllOnlinePlayerData(): CompletableFuture<Void?> {
-        val futures = mutableListOf<CompletableFuture<Void?>>()
-        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
-            futures += loadPlayerData(player.uniqueId)
-        }
-        return CompletableFuture.allOf(*futures.toTypedArray())
-    }
+    fun loadAllOnlinePlayerData(): CompletableFuture<Void?>
 
-    private fun saveAllOnlinePlayerData(): CompletableFuture<Void?> {
-        val futures = mutableListOf<CompletableFuture<Void?>>()
-        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
-            futures += savePlayerData(player.uniqueId)
-        }
-        return CompletableFuture.allOf(*futures.toTypedArray())
-    }
+    fun saveAndForgetAllOnlinePlayerData(): CompletableFuture<Void?>
 
-    fun saveAndForgetAllOnlinePlayerData(): CompletableFuture<Void?> {
-        val futures = mutableListOf<CompletableFuture<Void?>>()
-        plugin.server.onlinePlayers.forEach { player -> // TODO: Log exceptions
-            // TODO: See comment below
-            futures += savePlayerData(player.uniqueId).whenComplete { _, _ -> // This was line 124 from below stacktrace
-                forgetPlayerData(player.uniqueId)
-            }
-        }
-        return CompletableFuture.allOf(*futures.toTypedArray())
-    }
+    fun getConfig(configName: ConfigName): SavedConfig
 
-    /*
-    TODO: forEach { } in saveAndForgetAllOnlinePlayerData again causes issues on Paper when it's first loaded during shutdown
+    fun <T : SavedConfig> getConfig(configName: ConfigName, configurationClass: Class<T>): T
 
-    [09:27:15 ERROR]: Error occurred while disabling Basics v1.0-SNAPSHOT
-java.lang.NoClassDefFoundError: com/github/spigotbasics/core/module/BasicsModule$saveAndForgetAllOnlinePlayerData$1$1
-        at com.github.spigotbasics.core.module.BasicsModule$DefaultImpls.saveAndForgetAllOnlinePlayerData(BasicsModule.kt:124) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at com.github.spigotbasics.core.module.AbstractBasicsModule.saveAndForgetAllOnlinePlayerData(AbstractBasicsModule.kt:15) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at com.github.spigotbasics.core.module.manager.ModuleManager.disableModule(ModuleManager.kt:157) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at com.github.spigotbasics.core.module.manager.ModuleManager.disableAllModules(ModuleManager.kt:195) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at com.github.spigotbasics.core.module.manager.ModuleManager.disableAndUnloadAllModules(ModuleManager.kt:202) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at com.github.spigotbasics.plugin.BasicsPluginImpl.onDisable(BasicsPluginImpl.kt:109) ~[basics-1.0-SNAPSHOT-shaded.jar:?]
-        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:283) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
-        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:225) ~[paper-1.20.4.jar:git-Paper-388]
-        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugins(PaperPluginInstanceManager.java:149) ~[paper-1.20.4.jar:git-Paper-388]
-        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugins(PaperPluginManagerImpl.java:92) ~[paper-1.20.4.jar:git-Paper-388]
-        at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:528) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
-        at org.bukkit.craftbukkit.v1_20_R3.CraftServer.disablePlugins(CraftServer.java:568) ~[paper-1.20.4.jar:git-Paper-388]
-        at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:976) ~[paper-1.20.4.jar:git-Paper-388]
-        at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:821) ~[paper-1.20.4.jar:git-Paper-388]
-        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1253) ~[paper-1.20.4.jar:git-Paper-388]
-        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:321) ~[paper-1.20.4.jar:git-Paper-388]
-        at java.lang.Thread.run(Thread.java:833) ~[?:?]
-Caused by: java.lang.ClassNotFoundException: com.github.spigotbasics.core.module.BasicsModule$saveAndForgetAllOnlinePlayerData$1$1
-        at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:197) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
-        at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:164) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
-        at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
-        ... 17 more
-
+    /**
+     * Get namespaced resource name in the format <module-name>-<path>. Also removes leading slashes.
+     *
+     * @param path Path to the resource
+     * @return Namespaced resource name
      */
+    fun getNamespacedResourceName(path: String): String {
+        var newPath = path
 
+        if (path.startsWith("/")) {
+            newPath = path.substring(1)
+        }
+
+        return "${info.name}-$newPath"
+    }
 
 
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/BasicsModule.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/BasicsModule.kt
@@ -19,7 +19,7 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 
 /**
- * Common interfaces to be used by all modules. Implementations require a public constructor that takes in a [BasicsPlugin] and a [ModuleInfo].
+ * Represents a module. Implementations require a public constructor that takes in a [com.github.spigotbasics.core.module.loader.ModuleInstantiationContext].
  *
  * @constructor Create empty Basics plugin
  */
@@ -84,10 +84,13 @@ interface BasicsModule {
      */
     val eventBus: BasicsEventBus
 
-
-
+    /**
+     * This module's permission manager
+     */
     val permissionManager: BasicsPermissionManager
 
+
+    // ----- Module lifecycle -----
     /**
      * Called when the module is enabled
      *
@@ -96,9 +99,12 @@ interface BasicsModule {
 
     /**
      * Called when the module is disabled
-     *
      */
     fun onDisable() = Unit
+
+    fun reloadConfig()
+
+    // ----- Enabling / disabling methods -----
 
     fun enable(reloadConfig: Boolean)
 
@@ -106,11 +112,7 @@ interface BasicsModule {
 
     fun isEnabled(): Boolean
 
-    fun reloadConfig()
-
-    fun createCommand(name: String, permission: Permission): BasicsCommandBuilder
-
-    fun createStorage(name: String? = null): NamespacedStorage
+    // ----- PlayerData methods -----
 
     fun loadPlayerData(uuid: UUID): CompletableFuture<Void?> = CompletableFuture.completedFuture(null)
 
@@ -121,6 +123,12 @@ interface BasicsModule {
     fun loadAllOnlinePlayerData(): CompletableFuture<Void?>
 
     fun saveAndForgetAllOnlinePlayerData(): CompletableFuture<Void?>
+
+    // ----- Utility methods -----
+
+    fun createCommand(name: String, permission: Permission): BasicsCommandBuilder
+
+    fun createStorage(name: String? = null): NamespacedStorage
 
     fun getConfig(configName: ConfigName): SavedConfig
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/ModuleInfo.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/ModuleInfo.kt
@@ -1,5 +1,6 @@
 package com.github.spigotbasics.core.module
 
+import com.github.spigotbasics.core.exceptions.InvalidModuleException
 import org.bukkit.configuration.file.YamlConfiguration
 
 data class ModuleInfo(

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleInstantiationContext.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleInstantiationContext.kt
@@ -1,8 +1,7 @@
-package com.github.spigotbasics.core.module
+package com.github.spigotbasics.core.module.loader
 
 import com.github.spigotbasics.core.BasicsPlugin
-import com.github.spigotbasics.core.command.BasicsCommandManager
-import com.github.spigotbasics.core.module.loader.ModuleJarClassLoader
+import com.github.spigotbasics.core.module.ModuleInfo
 import java.io.File
 
 /**

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleJarClassLoader.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleJarClassLoader.kt
@@ -2,7 +2,7 @@ package com.github.spigotbasics.core.module.loader
 
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.module.BasicsModule
-import com.github.spigotbasics.core.module.ForbiddenFruitException
+import com.github.spigotbasics.core.exceptions.ForbiddenFruitException
 import org.bukkit.plugin.PluginManager
 import org.bukkit.scheduler.BukkitRunnable
 import org.bukkit.scheduler.BukkitScheduler

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleLoader.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/loader/ModuleLoader.kt
@@ -1,16 +1,13 @@
 package com.github.spigotbasics.core.module.loader
 
 import com.github.spigotbasics.core.BasicsPlugin
-import com.github.spigotbasics.core.Constants
 import com.github.spigotbasics.core.Constants.MODULE_YML_FILE_NAME
 import com.github.spigotbasics.core.module.BasicsModule
-import com.github.spigotbasics.core.module.InvalidModuleException
+import com.github.spigotbasics.core.exceptions.InvalidModuleException
 import com.github.spigotbasics.core.module.ModuleInfo
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
 import org.bukkit.configuration.InvalidConfigurationException
 import org.bukkit.configuration.file.YamlConfiguration
 import java.io.File
-import java.util.jar.JarFile
 
 class ModuleLoader
 @Throws(InvalidModuleException::class)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/manager/ModuleManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/manager/ModuleManager.kt
@@ -22,7 +22,7 @@ class ModuleManager(val plugin: BasicsPlugin, val modulesDirectory: File) {
     private val myLoadedModules: MutableList<BasicsModule> = mutableListOf()
 
     val loadedModules: List<BasicsModule>
-        get() = myLoadedModules.sortedBy { it.info.name } // TODO: Maybe have to call toList before calling sortedBy
+        get() = myLoadedModules.sortedBy { it.info.name }
 
     val enabledModules: List<BasicsModule>
         get() = myLoadedModules.filter { it.isEnabled() }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/module/manager/ModuleManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/module/manager/ModuleManager.kt
@@ -3,8 +3,8 @@ package com.github.spigotbasics.core.module.manager
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.BasicsPlugin
 import com.github.spigotbasics.core.module.BasicsModule
-import com.github.spigotbasics.core.module.InvalidModuleException
-import com.github.spigotbasics.core.module.ModuleAlreadyLoadedException
+import com.github.spigotbasics.core.exceptions.InvalidModuleException
+import com.github.spigotbasics.core.exceptions.ModuleAlreadyLoadedException
 import com.github.spigotbasics.core.module.loader.ModuleJarFileFilter
 import com.github.spigotbasics.core.module.loader.ModuleLoader
 import org.jetbrains.annotations.Blocking
@@ -13,7 +13,6 @@ import java.io.FileNotFoundException
 import java.lang.Thread.sleep
 import java.util.concurrent.CompletableFuture
 import java.util.logging.Level
-import kotlin.coroutines.suspendCoroutine
 
 class ModuleManager(val plugin: BasicsPlugin, val modulesDirectory: File) {
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/CorePlayerData.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/CorePlayerData.kt
@@ -5,18 +5,15 @@ import com.google.gson.JsonPrimitive
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
-class PlayerUUIDCache(storageManager: StorageManager) : Listener {
+class CorePlayerData(storageManager: StorageManager) {
 
     private val nameToUuid = storageManager.createStorage("player_name_to_uuid")
     private val uuidToName = storageManager.createStorage("player_uuid_to_name")
 
-    @EventHandler
-    internal fun onJoin(event: PlayerJoinEvent) {
-        store(event.player.name, event.player.uniqueId)
-    }
 
     fun getUuidForName(name: String): CompletableFuture<UUID?> {
         return nameToUuid.getJsonElement(name).thenApply {
@@ -28,13 +25,13 @@ class PlayerUUIDCache(storageManager: StorageManager) : Listener {
         }
     }
 
-    fun getNameForUuid(uuid: UUID): String? {
+    fun getNameForUuid(uuid: UUID): CompletableFuture<String?>? {
         return uuidToName.getJsonElement(uuid.toString()).thenApply {
             it?.asString
-        }.get()
+        }
     }
 
-    private fun store(name: String, uuid: UUID) {
+    fun storeNameAndUuid(name: String, uuid: UUID) {
         val jsonName = JsonPrimitive(name)
         val jsonUuid = JsonPrimitive(uuid.toString())
         uuidToName.setJsonElement(uuid.toString(), jsonName)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/CorePlayerDataListener.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/CorePlayerDataListener.kt
@@ -1,0 +1,15 @@
+package com.github.spigotbasics.core.playerdata
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+
+class CorePlayerDataListener(private val corePlayerData: CorePlayerData) : Listener{
+
+    @EventHandler
+    internal fun onJoin(event: PlayerJoinEvent) {
+        corePlayerData.storeNameAndUuid(event.player.name, event.player.uniqueId)
+    }
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/ModulePlayerDataLoader.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/ModulePlayerDataLoader.kt
@@ -1,4 +1,4 @@
-package com.github.spigotbasics.core.listener
+package com.github.spigotbasics.core.playerdata
 
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.messages.CoreMessages
@@ -13,13 +13,13 @@ import org.bukkit.event.player.PlayerQuitEvent
 import java.util.*
 import java.util.concurrent.*
 
-class PlayerDataListener(
+class ModulePlayerDataLoader(
     storageConfig: StorageConfig,
     private val moduleManager: ModuleManager,
     private val messages: CoreMessages
 ) : Listener {
 
-    private val logger = BasicsLoggerFactory.getCoreLogger(PlayerDataListener::class)
+    private val logger = BasicsLoggerFactory.getCoreLogger(ModulePlayerDataLoader::class)
 
     private val joinCacheDuration = storageConfig.joinCacheDuration
     private val joinTimeOut = storageConfig.joinTimeOut
@@ -73,6 +73,7 @@ class PlayerDataListener(
         }
     }
 
+    // TODO: Call this on shutdown - and on /reload? What about /module disable ?
     private fun saveAndForgetAll(uuid: UUID): CompletableFuture<Void?> {
         val futures = mutableListOf<CompletableFuture<Void?>>()
         moduleManager.enabledModules.forEach { module ->

--- a/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/PlayerUUIDCache.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/playerdata/PlayerUUIDCache.kt
@@ -1,0 +1,44 @@
+package com.github.spigotbasics.core.playerdata
+
+import com.github.spigotbasics.core.storage.StorageManager
+import com.google.gson.JsonPrimitive
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import java.util.*
+import java.util.concurrent.CompletableFuture
+
+class PlayerUUIDCache(storageManager: StorageManager) : Listener {
+
+    private val nameToUuid = storageManager.createStorage("player_name_to_uuid")
+    private val uuidToName = storageManager.createStorage("player_uuid_to_name")
+
+    @EventHandler
+    internal fun onJoin(event: PlayerJoinEvent) {
+        store(event.player.name, event.player.uniqueId)
+    }
+
+    fun getUuidForName(name: String): CompletableFuture<UUID?> {
+        return nameToUuid.getJsonElement(name).thenApply {
+            if (it != null) {
+                UUID.fromString(it.asString)
+            } else {
+                null
+            }
+        }
+    }
+
+    fun getNameForUuid(uuid: UUID): String? {
+        return uuidToName.getJsonElement(uuid.toString()).thenApply {
+            it?.asString
+        }.get()
+    }
+
+    private fun store(name: String, uuid: UUID) {
+        val jsonName = JsonPrimitive(name)
+        val jsonUuid = JsonPrimitive(uuid.toString())
+        uuidToName.setJsonElement(uuid.toString(), jsonName)
+        nameToUuid.setJsonElement(name, jsonUuid)
+    }
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/BasicsStorageAccessException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/BasicsStorageAccessException.kt
@@ -2,5 +2,8 @@ package com.github.spigotbasics.core.storage
 
 import java.io.IOException
 
-class BasicsStorageAccessException(message: String, e: Exception) : IOException(message, e) {
+class BasicsStorageAccessException : IOException {
+    constructor (message: String, e: Exception) : super(message, e)
+
+    constructor (message: String) : super(message)
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/IODelayedStorageBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/IODelayedStorageBackend.kt
@@ -1,5 +1,6 @@
 package com.github.spigotbasics.core.storage
 
+import com.github.spigotbasics.core.exceptions.BasicsStorageAccessException
 import com.google.gson.JsonElement
 import java.util.concurrent.CompletableFuture
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/IODelayedStorageBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/IODelayedStorageBackend.kt
@@ -3,19 +3,29 @@ package com.github.spigotbasics.core.storage
 import com.google.gson.JsonElement
 import java.util.concurrent.CompletableFuture
 
+// TODO: Get rid of this
+// TODO: Properly propagate exceptions in the async methods
 class IODelayedStorageBackend(private val backend: StorageBackend, private val ioDelay: Long): StorageBackend by backend {
 
     override fun getJsonElement(namespace: String, keyId: String): CompletableFuture<JsonElement?> {
         return CompletableFuture.supplyAsync {
-            Thread.sleep(ioDelay)
-            backend.getJsonElement(namespace, keyId).join()
+            try {
+                Thread.sleep(ioDelay)
+                backend.getJsonElement(namespace, keyId).join()
+            } catch (e: Exception) {
+                throw BasicsStorageAccessException("Could not read file $namespace/$keyId.json", e)
+            }
         }
     }
 
     override fun setJsonElement(namespace: String, keyId: String, value: JsonElement?): CompletableFuture<Void?> {
         return CompletableFuture.runAsync {
-            Thread.sleep(ioDelay)
-            backend.setJsonElement(namespace, keyId, value).join()
+            try {
+                Thread.sleep(ioDelay)
+                backend.setJsonElement(namespace, keyId, value).join()
+            } catch (e: Exception) {
+                throw BasicsStorageAccessException("Could not write file $namespace/$keyId.json", e)
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/MySQLDatabaseInfo.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/MySQLDatabaseInfo.kt
@@ -5,5 +5,6 @@ data class MySQLDatabaseInfo(
     val port: Int,
     val database: String,
     val username: String,
-    val password: String
+    val password: String,
+    val tablePrefix: String
 )

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageConfig.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageConfig.kt
@@ -42,6 +42,9 @@ class StorageConfig(private val plugin: BasicsPlugin, file: File) : SavedConfig(
     val mysqlPassword: String?
         get() = getString("mysql.password")
 
+    val mysqlTablePrefix: String
+        get() = getString("mysql.table-prefix") ?: "basics_"
+
     val ioDelay: Long
         get() = getDurationAsMillis("debug.artificial-io-delay", 0L)
 
@@ -55,7 +58,8 @@ class StorageConfig(private val plugin: BasicsPlugin, file: File) : SavedConfig(
             val database = mysqlDatabase ?: error("MySQL database not set")
             val username = mysqlUsername ?: error("MySQL username not set")
             val password = mysqlPassword ?: error("MySQL password not set")
-            return MySQLDatabaseInfo(host, port, database, username, password)
+            val tablePrefix = mysqlTablePrefix
+            return MySQLDatabaseInfo(host, port, database, username, password, tablePrefix)
         }
 
     private fun replaceDir(dir: String): String {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageConfig.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageConfig.kt
@@ -49,7 +49,14 @@ class StorageConfig(private val plugin: BasicsPlugin, file: File) : SavedConfig(
         get() = getDurationAsMillis("debug.artificial-io-delay", 0L)
 
     val sqlSleep: Double
-        get() = getDurationAsMillis("debug.sql-sleep-delay", 0L) / 1000.0
+        get() = getDurationAsMillis("debug.sql-sleep-delay", 0L) / 1_000.0
+
+    val joinTimeOut: Long
+        get() = getDurationAsMillis("load-player-data-on-join.timeout", 2_000)
+
+    val joinCacheDuration: Long
+        get() = getDurationAsMillis("load-player-data-on-join.cache-duration", 60_000)
+
 
     val mysqlInfo: MySQLDatabaseInfo
         get() {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageManager.kt
@@ -43,6 +43,10 @@ class StorageManager(configManager: CoreConfigManager) {
         return NamespacedStorage(backend, namespace)
     }
 
+    internal fun createCoreStorage(namespace: String): NamespacedStorage {
+        return createStorage("_$namespace")
+    }
+
     fun shutdown(): CompletableFuture<Void?> = backend.shutdown()
 
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageManager.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/StorageManager.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.core.storage
 
 import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.config.CoreConfigManager
+import com.github.spigotbasics.core.exceptions.BasicsStorageInitializeException
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.storage.backends.JsonBackend
 import com.github.spigotbasics.core.storage.backends.MySQLBackend

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/HikariBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/HikariBackend.kt
@@ -1,7 +1,7 @@
 package com.github.spigotbasics.core.storage.backends
 
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
-import com.github.spigotbasics.core.storage.BasicsStorageAccessException
+import com.github.spigotbasics.core.exceptions.BasicsStorageAccessException
 import com.github.spigotbasics.core.storage.StorageBackend
 import com.google.gson.JsonElement
 import com.google.gson.JsonParser

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/HikariBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/HikariBackend.kt
@@ -10,12 +10,13 @@ import com.zaxxer.hikari.HikariDataSource
 import java.io.IOException
 import java.sql.SQLException
 import java.util.concurrent.*
+import java.util.logging.Level
 
 internal abstract class HikariBackend(config: HikariConfig, sqlSleep: Double) : StorageBackend {
 
     private val logger = BasicsLoggerFactory.getCoreLogger(HikariBackend::class)
 
-    protected val selectSleepFunction = if(sqlSleep > 0) "SELECT SLEEP($sqlSleep);" else null
+    protected val selectSleepFunction = if(sqlSleep > 0) "SELECT SLEEP($sqlSleep);" else null // TODO: Get rid of this
 
     protected val dataSource = HikariDataSource(config)
 
@@ -34,6 +35,7 @@ internal abstract class HikariBackend(config: HikariConfig, sqlSleep: Double) : 
                 }
             }
         } catch (e: SQLException) {
+            logger.log(Level.SEVERE, "Could not execute create statement for namespace $namespace", e)
             throw (IOException(e))
         }
     }
@@ -56,6 +58,7 @@ internal abstract class HikariBackend(config: HikariConfig, sqlSleep: Double) : 
                     }
                 }
             } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Could not SELECT from $namespace", e)
                 throw BasicsStorageAccessException("Could not SELECT from $namespace", e)
             }
             null

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/JsonBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/JsonBackend.kt
@@ -1,7 +1,7 @@
 package com.github.spigotbasics.core.storage.backends
 
 import com.github.spigotbasics.core.logger.BasicsLoggerFactory
-import com.github.spigotbasics.core.storage.BasicsStorageAccessException
+import com.github.spigotbasics.core.exceptions.BasicsStorageAccessException
 import com.github.spigotbasics.core.storage.StorageBackend
 import com.github.spigotbasics.core.storage.StorageType
 import com.google.gson.JsonElement

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/JsonBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/JsonBackend.kt
@@ -1,5 +1,7 @@
 package com.github.spigotbasics.core.storage.backends
 
+import com.github.spigotbasics.core.logger.BasicsLoggerFactory
+import com.github.spigotbasics.core.storage.BasicsStorageAccessException
 import com.github.spigotbasics.core.storage.StorageBackend
 import com.github.spigotbasics.core.storage.StorageType
 import com.google.gson.JsonElement
@@ -7,10 +9,12 @@ import com.google.gson.JsonParser
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.CompletableFuture
+import java.util.logging.Level
 
 internal class JsonBackend(private val directory: File) : StorageBackend {
 
     override val type = StorageType.JSON
+    private val logger = BasicsLoggerFactory.getCoreLogger(this::class)
 
     init {
         if(directory.exists() && !directory.isDirectory) {
@@ -29,17 +33,22 @@ internal class JsonBackend(private val directory: File) : StorageBackend {
 
     override fun getJsonElement(namespace: String, keyId: String): CompletableFuture<JsonElement?> {
         return CompletableFuture.supplyAsync {
-            val file = getFile(namespace, keyId)
-            if (!file.parentFile.isDirectory) {
-                file.parentFile.mkdirs()
-            }
-            if (!file.exists()) {
-                return@supplyAsync null
-            } else {
-                file.reader().use { reader ->
-                    val json = JsonParser.parseReader(reader)
-                    return@supplyAsync json
+            try {
+                val file = getFile(namespace, keyId)
+                if (!file.parentFile.isDirectory) {
+                    file.parentFile.mkdirs()
                 }
+                if (!file.exists()) {
+                    return@supplyAsync null
+                } else {
+                    file.reader().use { reader ->
+                        val json = JsonParser.parseReader(reader)
+                        return@supplyAsync json
+                    }
+                }
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Could not read file $namespace/$keyId.json", e)
+                throw BasicsStorageAccessException("Could not read file $namespace/$keyId.json", e)
             }
         }
     }
@@ -47,28 +56,34 @@ internal class JsonBackend(private val directory: File) : StorageBackend {
 
     override fun setJsonElement(namespace: String, keyId: String, value: JsonElement?): CompletableFuture<Void?> {
         return CompletableFuture.runAsync {
-            val file = getFile(namespace, keyId)
-            if (value == null) {
-                val deleted = file.delete()
-                if(!deleted) {
-                    throw IllegalStateException("Could not delete file $file")
+            try {
+                val file = getFile(namespace, keyId)
+                if (value == null) {
+                    val deleted = file.delete()
+                    if (!deleted) {
+                        throw BasicsStorageAccessException("Could not delete file $file")
+                    }
+                } else {
+                    file.writeText(value.toString())
                 }
-            } else {
-                file.writeText(value.toString())
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Could not write file $namespace/$keyId.json", e) // TODO: Properly propagate exceptions in the async methods
+                throw BasicsStorageAccessException("Could not write file $namespace/$keyId.json", e)
             }
         }
     }
 
     override fun setupNamespace(namespace: String) {
-        if (!directory.isDirectory) {
-            val success = directory.mkdirs()
+        val subDir = File(directory, namespace)
+        if (!subDir.isDirectory) {
+            val success = subDir.mkdirs()
             if (!success) {
-                throw IOException("Could not create storage directory $directory")
+                throw IOException("Could not create storage directory ${subDir.absolutePath}")
             }
         }
     }
 
-    private fun getFile(key: String, user: String) = File(File(directory, key), "$user.json")
+    private fun getFile(namespace: String, keyId: String) = File(File(directory, namespace), "$keyId.json")
 
     override fun shutdown(): CompletableFuture<Void?> = CompletableFuture.completedFuture(null)
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/MySQLBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/MySQLBackend.kt
@@ -1,6 +1,6 @@
 package com.github.spigotbasics.core.storage.backends
 
-import com.github.spigotbasics.core.storage.BasicsStorageAccessException
+import com.github.spigotbasics.core.exceptions.BasicsStorageAccessException
 import com.github.spigotbasics.core.storage.MySQLDatabaseInfo
 import com.github.spigotbasics.core.storage.StorageType
 import com.google.gson.JsonElement

--- a/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/SQLiteBackend.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/storage/backends/SQLiteBackend.kt
@@ -1,6 +1,6 @@
 package com.github.spigotbasics.core.storage.backends
 
-import com.github.spigotbasics.core.storage.BasicsStorageAccessException
+import com.github.spigotbasics.core.exceptions.BasicsStorageAccessException
 import com.github.spigotbasics.core.storage.StorageType
 import com.google.gson.JsonElement
 

--- a/core/src/main/resources/custom-tags.yml
+++ b/core/src/main/resources/custom-tags.yml
@@ -1,13 +1,39 @@
-# This file allows you to use custom tags in messages.
+# This file allows you to add custom tags (basically like custom placeholders) in messages.
 
 # The following tags are included by default:
 #
 # <player-name>                  - Player's username
 # <player-name-genitive-suffix>  - Genitive suffix for player's username ('s or ')
 # <player-display-name>          - Player's display name
-# <papi:%some_placeholder%>      - Parses %some_placeholder% in PlaceholderAPI (if installed)
+
+########################################################################################################################
+
+# Tags for custom messages are declared in the following format:
+
+# <tag-name>:
+#   type: <tag-type>
+#   value: <tag-value>
+
+# <tag-name>  - The name of the tag. This is the <thing> that you will use in your messages.
+# <tag-type>  - The type of the tag. This can be either 'parsed' (default), 'unparsed', or 'color'.
+#                 - Unparsed tags are not processed any further (plain text)
+#                 - Parsed tags can contain other tags that will be evaluated
+#                 - Color tags are used to define colors and acn be used like <mycolor>text</mycolor>
+# <tag-value> - The value of the tag. This is the text that will be inserted into the message when the tag is used.
+
+########################################################################################################################
 
 # This example lets you use <player-dm> to insert a clickable version of a player's name
-test: "<hover:show_text:It's working!><red>This is a test</red></hover>"
-player-dm: "<gold><click:suggest_command:/msg <player-name> ><hover:show_text:Message <player-name>><player-display-name></hover></click></gold>"
-player-name-gold: "<gold><player-name></gold>"
+player-dm:
+  type: parsed
+  value: "<gold><click:suggest_command:/msg <player-name> ><hover:show_text:Message <player-name>><player-display-name></hover></click></gold>"
+
+# Player name with gold color
+player-name-gold:
+  type: parsed
+  value: "<gold><player-name></gold>"
+
+bright-green:
+  type: color
+  value: "#55FF55"
+

--- a/core/src/main/resources/custom-tags.yml
+++ b/core/src/main/resources/custom-tags.yml
@@ -1,10 +1,12 @@
 # This file allows you to add custom tags (basically like custom placeholders) in messages.
 
 # The following tags are included by default:
-#
 # <player-name>                  - Player's username
 # <player-name-genitive-suffix>  - Genitive suffix for player's username ('s or ')
 # <player-display-name>          - Player's display name
+
+# If you have PlaceholderAPI installed, you can also use any placeholders using the <papi:placeholder> tag:
+# <papi:%...%>                   - Any PlaceholderAPI placeholder
 
 ########################################################################################################################
 
@@ -18,7 +20,7 @@
 # <tag-type>  - The type of the tag. This can be either 'parsed' (default), 'unparsed', or 'color'.
 #                 - Unparsed tags are not processed any further (plain text)
 #                 - Parsed tags can contain other tags that will be evaluated
-#                 - Color tags are used to define colors and acn be used like <mycolor>text</mycolor>
+#                 - Color tags are used to define colors and can be used like <mycolor>text</mycolor>
 # <tag-value> - The value of the tag. This is the text that will be inserted into the message when the tag is used.
 
 ########################################################################################################################
@@ -35,5 +37,4 @@ player-name-gold:
 
 bright-green:
   type: color
-  value: "#55FF55"
-
+  value: "#77FF77"

--- a/core/src/main/resources/fix-class-loading.yml
+++ b/core/src/main/resources/fix-class-loading.yml
@@ -1,0 +1,8 @@
+set-enabled-during-ondisable: true
+call-iterator-on-empty-list: true
+abuse-classes:
+  BasicsModule: true
+  AbstractBasicsModule: true
+  ModuleManager: true
+  others:
+    # - java.lang.String

--- a/core/src/main/resources/messages.yml
+++ b/core/src/main/resources/messages.yml
@@ -14,3 +14,5 @@ player-not-found: "<red>Player not found: </red><color:#FF8888><argument></color
 command-not-from-console: "<red>This command can't be run from console!</red>"
 must-specify-player-from-console: "<red>You must specify a player when running this command from console!</red>"
 command-module-disabled: "<red>The module that registered this command is disabled!</red>"
+
+failed-to-load-data-on-join: "<red>[Basics] Failed to load player data in time - please try to join again!</red>"

--- a/core/src/main/resources/storage.yml
+++ b/core/src/main/resources/storage.yml
@@ -21,6 +21,15 @@ mysql:
   password: "password"
   table-prefix: "basics_"
 
+
+load-player-data-on-join:
+  # Time to wait on player join for player data to be loaded. If this time is exceeded, the player will be kicked
+  # and must join again. This is to prevent issues with player data not being loaded in time.
+  timeout: 2 s
+  # Time to wait for the player to rejoin after being kicked for not having their data loaded in time.
+  # If this time is exceeded, their data will be unloaded again.
+  cache-duration: 60 s
+
 debug:
   artificial-io-delay: 0 ms
   sql-sleep-delay: 0 ms

--- a/core/src/main/resources/storage.yml
+++ b/core/src/main/resources/storage.yml
@@ -19,6 +19,7 @@ mysql:
   database: "minecraft"
   username: "username"
   password: "password"
+  table-prefix: "basics_"
 
 debug:
   artificial-io-delay: 0 ms

--- a/modules/basics-announcements/src/main/kotlin/com/github/spigotbasics/modules/basicsannouncements/BasicsAnnouncementsModule.kt
+++ b/modules/basics-announcements/src/main/kotlin/com/github/spigotbasics/modules/basicsannouncements/BasicsAnnouncementsModule.kt
@@ -2,7 +2,7 @@ package com.github.spigotbasics.modules.basicsannouncements
 
 import com.github.spigotbasics.core.extensions.getDurationAsTicks
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import java.util.concurrent.ThreadLocalRandom
 
 class BasicsAnnouncementsModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {

--- a/modules/basics-announcements/src/main/resources/config.yml
+++ b/modules/basics-announcements/src/main/resources/config.yml
@@ -1,8 +1,9 @@
 interval: 2 minutes
-pick-random: false
+pick-random: true
 messages:
   - "<i><gradient:#00ff00:#00cc00>\"OMG YOU'RE USING BASICS???!!!\"</gradient></i> Basics makes players wet since 2024!"
   - "<rainbow>Check out the Basics repo on <click:open_url:https://github.com/SpigotBasics/basics><hover:show_text:'Click to visit GitHub'><red>GitHub</red></hover>!</rainbow>"
   - "\"With <bold>Basics</bold>, server management has never been this simple. Say goodbye to headaches and hello to a smooth gaming experience!\"\n- CMarco (AI)"
   - "<gradient:#ff0000:#cc0000>\"Basics is the best plugin ever!\"</gradient>\n- <gradient:#0000ff:#0000cc>mfnalex</gradient>"
   - "<gray>(You can customize these messages in the basics-announcements module)</gray>"
+  - "<green2>If you got PlaceholderAPI installed, you can use any placeholder: <papi:%server_tps%></green2>"

--- a/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BasicsBroadcastModule.kt
+++ b/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BasicsBroadcastModule.kt
@@ -1,8 +1,7 @@
 package com.github.spigotbasics.modules.basicsbroadcast
 
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
-import org.bukkit.Bukkit
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 
 class BasicsBroadcastModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
 
@@ -10,9 +9,7 @@ class BasicsBroadcastModule(context: ModuleInstantiationContext) : AbstractBasic
     val parsedPerm = permissionManager.createSimplePermission("basics.broadcast.parsed", "Allows the user to broadcast parsed messages")
 
     override fun onEnable() {
-        createCommand()
-            .name("broadcast")
-            .permission(commandPerm)
+        createCommand("broadcast", commandPerm)
             .description("Broadcasts a message to all players")
             .usage("/broadcast [--parsed] <message>")
             .executor(BroadcastExecutor(this))

--- a/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BroadcastExecutor.kt
+++ b/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BroadcastExecutor.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.modules.basicsbroadcast
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
 
 class BroadcastExecutor(private val module: BasicsBroadcastModule) : BasicsCommandExecutor(module) {
@@ -19,7 +20,7 @@ class BroadcastExecutor(private val module: BasicsBroadcastModule) : BasicsComma
 
         if(parseMini) {
             requirePermission(context.sender, module.parsedPerm)
-            message = messageFactory.createMessage(text)
+            message = messageFactory.createMessage(text).concerns(context.sender as? Player)
         }
 
         message.sendToAllPlayers()

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
@@ -4,7 +4,7 @@ import com.github.spigotbasics.core.Spiper
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.extensions.getAsNewLineSeparatedString
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.event.EventPriority
 import org.bukkit.event.player.AsyncPlayerChatEvent
 

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
@@ -1,7 +1,7 @@
 package com.github.spigotbasics.modules.basicscore
 
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.permissions.PermissionDefault
 
 class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
@@ -13,7 +13,7 @@ class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModu
     )
 
     override fun onEnable() {
-        createCommand().name("module").permission(permission).usage("/module [command]").executor(ModulesCommand(this)).register()
+        createCommand("module", permission).usage("/module [command]").executor(ModulesCommand(this)).register()
     }
 
 }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/ModulesCommand.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/ModulesCommand.kt
@@ -172,7 +172,7 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
     private fun filesNamesUnloadedModules(): List<String> {
         return moduleManager.modulesDirectory.listFiles()?.filter {
             for (module in moduleManager.loadedModules) {
-                if (module.moduleFile == it) {
+                if (module.file == it) {
                     return@filter false
                 }
             }

--- a/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/BasicsGamemodeModule.kt
+++ b/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/BasicsGamemodeModule.kt
@@ -3,7 +3,7 @@ package com.github.spigotbasics.modules.basicsgamemode
 import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.GameMode
 import org.bukkit.permissions.Permission
 
@@ -32,9 +32,7 @@ class BasicsGamemodeModule(context: ModuleInstantiationContext) : AbstractBasics
     }
 
     override fun onEnable() {
-        createCommand()
-            .name("gamemode")
-            .permission(perm)
+        createCommand("gamemode", perm)
             .description("Changes the player's game mode")
             .usage("/gamemode <mode> [player]")
             .executor(GamemodeExecutor(this))

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
@@ -32,14 +32,16 @@ class BasicsHomesModule(context: ModuleInstantiationContext) : AbstractBasicsMod
 
     val permissionDelHome = permissionManager.createSimplePermission("basics.delhome", "Allows to access the /delhome command")
 
-    val msgHomeSet get() = messages.getMessage("home-set")
-    val msgHomeDeleted get() = messages.getMessage("home-deleted")
-    val msgHomeTeleported get() = messages.getMessage("home-teleported")
-    val msgHomeNotFound get() = messages.getMessage("home-not-found")
+    fun msgHomeSet(home: Home) = messages.getMessage("home-set").tagUnparsed("home", home.name)
+    fun msgHomeDeleted(home: Home) = messages.getMessage("home-deleted").tagUnparsed("home", home.name)
+    fun msgHomeTeleported(home: Home) = messages.getMessage("home-teleported").tagUnparsed("home", home.name)
+    fun msgHomeNotFound(name: String) = messages.getMessage("home-not-found").tagUnparsed("home", name)
     val msgHomeNoneSet get() = messages.getMessage("home-none-set")
-    val msgHomeLimitReached get() = messages.getMessage("home-limit-reached")
+    fun msgHomeLimitReached(limit: Int) = messages.getMessage("home-limit-reached").tagUnparsed("limit", limit.toString())
     val msgHomeListEntry get() = messages.getMessage("home-list-entry")
     val msgHomeListSeparator get() = messages.getMessage("home-list-separator")
+
+    fun msgWorldNotLoaded(worldName: String) = messages.getMessage("home-world-not-loaded").tagUnparsed("world", worldName)
 
     override fun onEnable() {
         storage = createStorage()
@@ -137,7 +139,7 @@ class BasicsHomesModule(context: ModuleInstantiationContext) : AbstractBasicsMod
         val home = homeList.getHome(homeName)
 
         if(home == null) {
-            msgHomeNotFound.tagUnparsed("home", homeName).sendToSender(player)
+            msgHomeNotFound(homeName).sendToSender(player)
             return Either.Right(true)
         }
 

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
@@ -5,14 +5,13 @@ import com.github.spigotbasics.core.Serialization
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import com.github.spigotbasics.core.storage.NamespacedStorage
 import com.github.spigotbasics.modules.basicshomes.commands.DelHomeCommand
 import com.github.spigotbasics.modules.basicshomes.commands.HomeCommand
 import com.github.spigotbasics.modules.basicshomes.commands.SetHomeCommand
 import com.github.spigotbasics.modules.basicshomes.data.Home
 import com.github.spigotbasics.modules.basicshomes.data.HomeList
-import com.google.gson.TypeAdapter
 import org.bukkit.entity.Player
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -46,25 +45,19 @@ class BasicsHomesModule(context: ModuleInstantiationContext) : AbstractBasicsMod
     override fun onEnable() {
         storage = createStorage()
 
-        createCommand()
-            .name("home")
-            .permission(permissionHome)
+        createCommand("home", permissionHome)
             .description("Teleports you to one of your homes")
             .usage("/home [name]")
             .executor(HomeCommand(this))
             .register()
 
-        createCommand()
-            .name("sethome")
-            .permission(permissionSetHome)
+        createCommand("sethome", permissionSetHome)
             .description("Sets a home")
             .usage("/sethome [name]")
             .executor(SetHomeCommand(this))
             .register()
 
-        createCommand()
-            .name("delhome")
-            .permission(permissionDelHome)
+        createCommand("delhome", permissionDelHome)
             .description("Deletes a home")
             .usage("/delhome [name]")
             .executor(DelHomeCommand(this))

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/DelHomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/DelHomeCommand.kt
@@ -21,7 +21,7 @@ class DelHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
         val player = requirePlayerOrMustSpecifyPlayerFromConsole(context.sender)
 
         module.getHomeList(player.uniqueId).removeHome(home)
-        module.msgHomeDeleted.tagUnparsed("home", home.name).sendToSender(player)
+        module.msgHomeDeleted(home).sendToSender(player)
         return true
     }
 

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
@@ -6,7 +6,7 @@ import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
 import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
 import com.github.spigotbasics.core.extensions.partialMatches
-import com.github.spigotbasics.core.extensions.toLocation
+import com.github.spigotbasics.core.model.toLocation
 import com.github.spigotbasics.modules.basicshomes.BasicsHomesModule
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerTeleportEvent

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
@@ -4,7 +4,9 @@ import com.github.spigotbasics.common.Either
 import com.github.spigotbasics.core.Spiper
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
 import com.github.spigotbasics.core.extensions.partialMatches
+import com.github.spigotbasics.core.extensions.toLocation
 import com.github.spigotbasics.modules.basicshomes.BasicsHomesModule
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerTeleportEvent
@@ -19,8 +21,12 @@ class HomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecutor
         val home = (result as Either.Left).value
         val player = requirePlayerOrMustSpecifyPlayerFromConsole(context.sender)
 
-        Spiper.teleportAsync(player, home.toLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN)
-        module.msgHomeTeleported.tagUnparsed("home", home.name).sendToSender(player)
+        try {
+            Spiper.teleportAsync(player, home.location.toLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN)
+            module.msgHomeTeleported(home).sendToSender(player)
+        } catch (e: WorldNotLoadedException) {
+            module.msgWorldNotLoaded(home.location.world).sendToSender(player)
+        }
         return true
     }
 

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/SetHomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/SetHomeCommand.kt
@@ -43,7 +43,7 @@ class SetHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
 
                 } else {
                     // ... and they're not replacing that one, that's not okay.
-                    module.msgHomeLimitReached.tagUnparsed("limit", "1")
+                    module.msgHomeLimitReached(1)
                         .sendToSender(player)
 
                     return true
@@ -60,14 +60,14 @@ class SetHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
         }
 
         if (!isOkay) {
-            module.msgHomeLimitReached.tagUnparsed("limit", maxAllowed.toString()).sendToSender(player)
+            module.msgHomeLimitReached(maxAllowed).sendToSender(player)
             return true
         }
 
         val home = Home(homeName, location)
 
         homeList.addHome(home)
-        module.msgHomeSet.tagUnparsed("home", homeName).sendToSender(player)
+        module.msgHomeSet(home).sendToSender(player)
         return true
     }
 

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/data/Home.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/data/Home.kt
@@ -1,10 +1,8 @@
 package com.github.spigotbasics.modules.basicshomes.data
 
-import com.github.spigotbasics.common.SimpleLocation
-import com.github.spigotbasics.core.extensions.toSimpleLocation
-import org.bukkit.Bukkit
+import com.github.spigotbasics.core.model.SimpleLocation
+import com.github.spigotbasics.core.model.toSimpleLocation
 import org.bukkit.Location
-import org.bukkit.World
 
 data class Home(val name: String, val location: SimpleLocation) {
     constructor(name: String, location: Location) : this(name, location.toSimpleLocation())

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/data/Home.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/data/Home.kt
@@ -1,26 +1,12 @@
 package com.github.spigotbasics.modules.basicshomes.data
 
+import com.github.spigotbasics.common.SimpleLocation
+import com.github.spigotbasics.core.extensions.toSimpleLocation
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.World
 
-data class Home(val name: String, val worldName: String, val x: Double, val y: Double, val z: Double, val yaw: Float, val pitch: Float) {
-    constructor(name: String, location: Location) : this(
-        name,
-        location.world?.name ?: error("Location must have a world"),
-        location.x,
-        location.y,
-        location.z,
-        location.yaw,
-        location.pitch
-    )
-
-    fun toLocation(): Location {
-        return Location(getWorld() ?: error("World $worldName does not exist or is not loaded"), x, y, z, yaw, pitch)
-    }
-
-    fun getWorld(): World? {
-        return Bukkit.getWorld(worldName)
-    }
+data class Home(val name: String, val location: SimpleLocation) {
+    constructor(name: String, location: Location) : this(name, location.toSimpleLocation())
 
 }

--- a/modules/basics-homes/src/main/resources/messages.yml
+++ b/modules/basics-homes/src/main/resources/messages.yml
@@ -7,3 +7,4 @@ home-limit-reached: "<red>You cannot set more than <gold><limit></gold> homes.</
 home-list: "<green>Available homes: <gold><homes></gold></green>"
 home-list-entry: "<gold><click:run_command:/home <home-name>><home-name></click></gold>"
 home-list-separator: "<gray>, </gray>"
+home-world-not-loaded: "<red>World <gold><world></gold> is not loaded.</red>"

--- a/modules/basics-join-leave-messages/src/main/kotlin/com/github/spigotbasics/modules/joinmessages/JoinMessagesModule.kt
+++ b/modules/basics-join-leave-messages/src/main/kotlin/com/github/spigotbasics/modules/joinmessages/JoinMessagesModule.kt
@@ -1,8 +1,7 @@
 package com.github.spigotbasics.modules.joinmessages
 
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
-import org.bukkit.event.EventHandler
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent

--- a/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/BasicsMsgModule.kt
+++ b/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/BasicsMsgModule.kt
@@ -2,7 +2,7 @@ package com.github.spigotbasics.modules.basicsmsg
 
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.permissions.PermissionDefault
 
 class BasicsMsgModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
@@ -26,8 +26,7 @@ class BasicsMsgModule(context: ModuleInstantiationContext) : AbstractBasicsModul
     )
 
     override fun onEnable() {
-        createCommand().name("msg")
-            .permission(permission)
+        createCommand("msg", permission)
             .description("Sends a private message to another player")
             .usage("/msg <player> <message>")
             .executor(MsgExecutor(this))

--- a/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/BasicsRepairModule.kt
+++ b/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/BasicsRepairModule.kt
@@ -3,7 +3,7 @@ package com.github.spigotbasics.modules.basicsrepair
 import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.AbstractBasicsModule
-import com.github.spigotbasics.core.module.ModuleInstantiationContext
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 
 class BasicsRepairModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
 
@@ -26,9 +26,8 @@ class BasicsRepairModule(context: ModuleInstantiationContext) : AbstractBasicsMo
     val permissionOthers = permissionManager.createSimplePermission("basics.repair.others", "Allows to repair other players' items")
 
     override fun onEnable() {
-        createCommand().name("repair")
+        createCommand("repair", permission)
             .usage("/repair [--all] [player]")
-            .permission(permission)
             .description("Repairs an item")
             .executor(RepairCommand(this))
             .register()

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -1,5 +1,5 @@
 tasks.register("copyAllModulesToTestServer") {
-    group = "testserver"
+    group  = "basics-test"
     description = "Copies all modules to the test server"
     val copyAllModulesTask = this
     subprojects.forEach { module ->
@@ -10,6 +10,6 @@ tasks.register("copyAllModulesToTestServer") {
 }
 
 tasks.register("createModule", CreateModule::class) {
-    group = "module"
+    group = "basics"
     description = "Creates a new module"
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -39,7 +39,7 @@ tasks.shadowJar {
 }
 
 tasks.register("copyPluginToTestServer", Copy::class) {
-    group = "testserver"
+    group  = "basics-test"
     description = "Copies the plugin to the test server"
     from(tasks.shadowJar.get().archiveFile)
     into(getServerPluginsDirectory())

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsDebugCommand.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsDebugCommand.kt
@@ -71,17 +71,16 @@ class BasicsDebugCommand(private val plugin: BasicsPluginImpl) : TabExecutor {
     }
 
     private fun showForSender(sender: CommandSender) {
-        val cachedLoginData = plugin.playerDataListener.cachedLoginData
-        val scheduledClearCacheFutures = plugin.playerDataListener.scheduledClearCacheFutures
+        val cachedLoginData = plugin.modulePlayerDataLoader.cachedLoginData
+        val scheduledClearCacheFutures = plugin.modulePlayerDataLoader.scheduledClearCacheFutures
 
         val output = """
-                
-                PlayerDataListener:
-                  -             cached login data: <cached-login-data>
-                  - scheduled clear cache futures: <scheduled-clear-cache-futures>
-                
-                
-            """.trimIndent()
+
+PlayerDataListener:
+  -             cached login data: <cached-login-data>
+  - scheduled clear cache futures: <scheduled-clear-cache-futures>
+
+"""
 
         val message = plugin.messageFactory.createMessage(output)
             .tagMessage("cached-login-data", shouldBe(cachedLoginData.size, 0))

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsDebugCommand.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsDebugCommand.kt
@@ -1,0 +1,105 @@
+package com.github.spigotbasics.plugin
+
+import com.github.spigotbasics.core.extensions.partialMatches
+import com.github.spigotbasics.core.messages.Message
+import com.github.spigotbasics.core.scheduler.BasicsScheduler
+import com.github.spigotbasics.core.util.DurationParser
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabExecutor
+
+class BasicsDebugCommand(private val plugin: BasicsPluginImpl) : TabExecutor {
+
+    override fun onTabComplete(
+        sender: CommandSender,
+        command: Command,
+        label: String,
+        args: Array<out String>
+    ): MutableList<String> {
+        if (args.size == 1) {
+            return listOf("start", "stop").partialMatches(args.get(0))
+        } else {
+            return mutableListOf()
+        }
+    }
+
+    private val tasks: MutableMap<CommandSender, Int> = mutableMapOf()
+    private val scheduler = BasicsScheduler(plugin)
+
+    fun startTask(sender: CommandSender, delay: Long) {
+        stopTask(sender)
+        val taskId = scheduler.runTimer(0, delay) {
+            showForSender(sender)
+        }
+        tasks[sender] = taskId
+    }
+
+    private fun stopTask(sender: CommandSender) {
+        tasks[sender]?.let {
+            scheduler.kill(it)
+            tasks.remove(sender)
+        }
+    }
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        when (args.size) {
+            0 -> {
+                showForSender(sender)
+                return true
+            }
+
+            1 -> return when (args[0]) {
+                "start" -> {
+                    startTask(sender, 20)
+                    true
+                }
+
+                "stop" -> {
+                    stopTask(sender)
+                    true
+                }
+
+                else -> false
+            }
+
+            2 -> return if (args[0] == "start") {
+                startTask(sender, DurationParser.parseDurationToTicks(args[1]))
+                true
+            } else false
+        }
+        return false
+    }
+
+    private fun showForSender(sender: CommandSender) {
+        val cachedLoginData = plugin.playerDataListener.cachedLoginData
+        val scheduledClearCacheFutures = plugin.playerDataListener.scheduledClearCacheFutures
+
+        val output = """
+                
+                PlayerDataListener:
+                  -             cached login data: <cached-login-data>
+                  - scheduled clear cache futures: <scheduled-clear-cache-futures>
+                
+                
+            """.trimIndent()
+
+        val message = plugin.messageFactory.createMessage(output)
+            .tagMessage("cached-login-data", shouldBe(cachedLoginData.size, 0))
+            .tagMessage(
+                "scheduled-clear-cache-futures",
+                shouldBe(scheduledClearCacheFutures.size, cachedLoginData.size)
+            )
+
+        message.sendToSender(sender)
+    }
+
+    fun <T : Any> shouldBe(value: T, expected: T): Message {
+        return plugin.messageFactory.createMessage(
+            if (value == expected) {
+                "<green>OK $value</green>"
+            } else {
+                "<red>!! $value (should be $expected)</red>"
+            }
+        )
+    }
+}

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -11,7 +11,7 @@ import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.messages.AudienceProvider
 import com.github.spigotbasics.core.messages.CoreMessages
 import com.github.spigotbasics.core.messages.MessageFactory
-import com.github.spigotbasics.core.messages.TagResolverFactory
+import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
 import com.github.spigotbasics.core.playerdata.CorePlayerData
 import com.github.spigotbasics.core.playerdata.CorePlayerDataListener

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -49,7 +49,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
 
     private val logger = BasicsLoggerFactory.getCoreLogger(this::class)
 
-    private val playerDataListener = PlayerDataListener(moduleManager)
+    internal val playerDataListener = PlayerDataListener(storageManager.config, moduleManager, messages)
     //override fun getLogger() = logger
 
     /**
@@ -90,6 +90,8 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
         moduleManager.loadAndEnableAllModulesFromModulesFolder()
         reloadCustomTags()
         server.pluginManager.registerEvents(playerDataListener, this)
+
+        getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
     }
 
 

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -1,9 +1,6 @@
 package com.github.spigotbasics.plugin
 
-import com.github.spigotbasics.core.BasicsPlugin
-import com.github.spigotbasics.core.Constants
-import com.github.spigotbasics.core.MinecraftVersion
-import com.github.spigotbasics.core.Spiper
+import com.github.spigotbasics.core.*
 import com.github.spigotbasics.core.config.CoreConfigManager
 import com.github.spigotbasics.core.config.FixClassLoadingConfig
 import com.github.spigotbasics.core.playerdata.ModulePlayerDataLoader
@@ -74,6 +71,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
     }
 
     override fun onLoad() {
+        Basics.setPlugin(this)
         if (!moduleFolder.isDirectory) {
             logger.info("Creating modules folder at ${moduleFolder.absolutePath}")
             moduleFolder.mkdirs()

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -99,6 +99,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
 
         moduleManager.loadAndEnableAllModulesFromModulesFolder()
         reloadCustomTags()
+        server.pluginManager.registerEvents(tagResolverFactory.Listener(), this)
         server.pluginManager.registerEvents(modulePlayerDataLoader, this)
 
         getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
@@ -106,7 +107,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
 
 
     private fun reloadCustomTags() {
-        tagResolverFactory.loadCustomTags(
+        tagResolverFactory.loadAndCacheAllTagResolvers(
             coreConfigManager.getConfig(
                 Constants.CUSTOM_TAGS_FILE_NAME,
                 Constants.CUSTOM_TAGS_FILE_NAME,

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -12,6 +12,7 @@ import com.github.spigotbasics.core.messages.CoreMessages
 import com.github.spigotbasics.core.messages.MessageFactory
 import com.github.spigotbasics.core.messages.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
+import com.github.spigotbasics.core.playerdata.PlayerUUIDCache
 import com.github.spigotbasics.core.storage.StorageManager
 import com.github.spigotbasics.core.util.ClassLoaderFix
 import com.github.spigotbasics.pipe.SpigotPaperFacade
@@ -42,7 +43,9 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
     override val coreConfigManager: CoreConfigManager = CoreConfigManager(this, messageFactory)
     override val messages: CoreMessages =
         coreConfigManager.getConfig("messages.yml", "messages.yml", CoreMessages::class.java, CoreMessages::class.java)
-    override val storageManager: StorageManager by lazy { StorageManager(coreConfigManager) }
+    override val storageManager: StorageManager /*by lazy*/ =  StorageManager(coreConfigManager)
+
+    override val playerUUIDCache: PlayerUUIDCache = PlayerUUIDCache(storageManager)
 
     private val logger = BasicsLoggerFactory.getCoreLogger(this::class)
 
@@ -81,7 +84,8 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
             return
         }
 
-        ::storageManager.get()
+        // ::storageManager.get()
+        server.pluginManager.registerEvents(playerUUIDCache, this)
 
         moduleManager.loadAndEnableAllModulesFromModulesFolder()
         reloadCustomTags()

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -2,5 +2,9 @@ name: Basics
 version: "${pluginVersion}"
 main: com.github.spigotbasics.plugin.BasicsPluginImpl
 api-version: "1.13"
-authors:
-  - cool people
+authors: [ "https://github.com/SpigotBasics/basics/graphs/contributors" ]
+commands:
+  basicsdebug:
+    description: "Debugging commands for Basics"
+    permission: basics.debug
+    usage: "/<command> [start <interval>|stop]"


### PR DESCRIPTION
- Added Basics singleton
- Revamped TagResolverFactory
  - Now caches per-player and global tag resolvers
  - Supports <papi:%any_placeholder%> Papi Placeholders
- Improved loading and caching playerdata on join
- Added a Player Name <> UUID Cache
- Added a /basicsdebug command (doesn't do much atm)
- Refactored BasicsModule and AbstractBasicsModule methods
- and more