### PR TITLE
Switched command return values from Boolean to CommandResult

### DIFF
--- a/buildSrc/src/main/kotlin/CreateModule.kt
+++ b/buildSrc/src/main/kotlin/CreateModule.kt
@@ -59,8 +59,8 @@ open class CreateModule : DefaultTask() {
     }
 
     fun copySkeletonTo(skeleton: String, target: File) {
-        val skeleton = File(project.projectDir, skeleton)
-        skeleton.copyRecursively(target)
+        val skeletonDir = File(project.projectDir, skeleton)
+        skeletonDir.copyRecursively(target)
     }
 
     fun replaceInFilesAndFilenames(rootDirectory: File, replacements: Map<String, String>) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,9 +24,19 @@ dependencies {
     api(project(":pipe:facade"))
     testImplementation(libs.gson)
     api(libs.gson)
-
-
 }
+
+tasks.shadowJar {
+    listOf(
+        "net.kyori",
+        "com.tcoded",
+        "com.zaxxer",
+        "io.papermc.lib",
+        ).forEach {
+        relocate(it, "com.github.spigotbasics.shaded.$it")
+    }
+}
+
 
 
 tasks.processResources {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommand.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommand.kt
@@ -1,10 +1,15 @@
 package com.github.spigotbasics.core.command
 
+import com.github.spigotbasics.core.logger.BasicsLoggerFactory
 import com.github.spigotbasics.core.messages.CoreMessages
+import com.github.spigotbasics.core.messages.MessageFactory
+import com.github.spigotbasics.core.messages.tags.CustomTag
+import com.github.spigotbasics.core.messages.tags.MessageTagProvider
 import org.bukkit.Location
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Entity
+import java.util.logging.Level
 
 
 /**
@@ -13,25 +18,33 @@ import org.bukkit.entity.Entity
  * @property info Command info
  * @property executor Command executor
  */
-class BasicsCommand internal constructor (
+class BasicsCommand internal constructor(
     var info: CommandInfo,
     private var executor: BasicsCommandExecutor?,
-    val coreMessages: CoreMessages
+    val coreMessages: CoreMessages,
+    val messageFactory: MessageFactory
 ) :
-    Command(info.name) {
+    Command(info.name)/*, MessageTagProvider */{
 
-        init {
-            val permString = info.permission.name
-            permission = permString
-            description = info.description ?: ""
-            usage = info.usage ?: "/$name"
-            permissionMessage = info.permissionMessage.tagUnparsed("permission", permString).toLegacyString()
-        }
+    private val logger = BasicsLoggerFactory.getCoreLogger(BasicsCommand::class)
 
-    override fun execute(sender: CommandSender, commandLabel: String, origArgs: Array<out String>?): Boolean {
+    init {
+        val permString = info.permission.name
+        permission = permString
+        description = info.description ?: ""
+        usage = info.usage ?: "/$name"
+        permissionMessage = info.permissionMessage.tagUnparsed("permission", permString).toLegacyString()
+    }
+
+//    private val customUsageMessage = messageFactory.createMessage(
+//        "<red>Invalid command usage.</red>",
+//        "<red>Usage: </red><gold><usage></gold>"
+//    ).tagParsed("usage", usage).tagParsed("command", name)
+
+    override fun execute(sender: CommandSender, commandLabel: String, origArgs: Array<out String>): Boolean {
         try {
 
-            val args = origArgs?.toMutableList() ?: mutableListOf()
+            val args = origArgs.toMutableList() ?: mutableListOf()
 
             val context = BasicsCommandContext(
                 sender = sender,
@@ -41,22 +54,28 @@ class BasicsCommand internal constructor (
                 location = if (sender is Entity) sender.location else null
             )
 
-            if(executor == null) {
+            if (executor == null) {
                 coreMessages.commandModuleDisabled.sendToSender(sender)
                 return true
             }
 
             val returned = executor!!.execute(context)
 
-            if (!returned) {
-                sender.sendMessage("Usage: $usage") // TODO: Use messages instead of Strings
-                return false
+//            if (returned == CommandResult.GENERIC_USAGE) {
+//                customUsageMessage.sendToSender(sender)
+//                return false
+//            }
+
+            try {
+                returned?.process(context)
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Error processing command result for ${info.name}", e)
             }
 
             return true
 
         } catch (e: BasicsCommandException) {
-
+            // These exceptions are expected to be thrown
             return true
         }
     }
@@ -69,7 +88,7 @@ class BasicsCommand internal constructor (
     override fun tabComplete(
         sender: CommandSender,
         alias: String,
-        args: Array<out String>?,
+        args: Array<out String>,
         location: Location?
     ): MutableList<String> {
         val context = BasicsCommandContext(
@@ -79,7 +98,7 @@ class BasicsCommand internal constructor (
             args = args?.toMutableList() ?: mutableListOf(),
             location = location
         )
-        if(executor == null) return mutableListOf()
+        if (executor == null) return mutableListOf()
         val result = executor!!.tabComplete(context)
         return result ?: super.tabComplete(sender, alias, args, location)
     }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommand.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommand.kt
@@ -32,7 +32,7 @@ class BasicsCommand internal constructor(
         val permString = info.permission.name
         permission = permString
         description = info.description ?: ""
-        usage = info.usage ?: "/$name"
+        usage = info.usage
         permissionMessage = info.permissionMessage.tagUnparsed("permission", permString).toLegacyString()
     }
 
@@ -42,7 +42,7 @@ class BasicsCommand internal constructor(
 //    ).tagParsed("usage", usage).tagParsed("command", name)
 
     override fun execute(sender: CommandSender, commandLabel: String, origArgs: Array<out String>): Boolean {
-        try {
+
 
             val args = origArgs.toMutableList() ?: mutableListOf()
 
@@ -59,23 +59,25 @@ class BasicsCommand internal constructor(
                 return true
             }
 
-            val returned = executor!!.execute(context)
+        var returned: CommandResult?
+        try {
 
-//            if (returned == CommandResult.GENERIC_USAGE) {
-//                customUsageMessage.sendToSender(sender)
-//                return false
-//            }
+            returned = executor!!.execute(context)
 
             try {
                 returned?.process(context)
             } catch (e: Exception) {
-                logger.log(Level.SEVERE, "Error processing command result for ${info.name}", e)
+                logger.log(Level.SEVERE, "Error processing returned command result for ${info.name}", e)
             }
 
             return true
 
         } catch (e: BasicsCommandException) {
-            // These exceptions are expected to be thrown
+            try {
+                e.commandResult.process(context)
+            } catch (e: Exception) {
+                logger.log(Level.SEVERE, "Error processing thrown command result for ${info.name}", e)
+            }
             return true
         }
     }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
@@ -4,7 +4,11 @@ import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.BasicsModule
 import org.bukkit.permissions.Permission
 
-class BasicsCommandBuilder(private val module: BasicsModule, private val name: String, private val permission: Permission) {
+class BasicsCommandBuilder(
+    private val module: BasicsModule,
+    private val name: String,
+    private val permission: Permission
+) {
 
     private var permissionMessage: Message = module.plugin.messages.noPermission
     private var description: String? = null
@@ -18,9 +22,9 @@ class BasicsCommandBuilder(private val module: BasicsModule, private val name: S
     fun aliases(aliases: List<String>) = apply { this.aliases = aliases }
     fun executor(executor: BasicsCommandExecutor) = apply { this.executor = executor }
 
-    fun executor(executor: (BasicsCommandContext) -> Boolean) = apply {
+    fun executor(executor: (BasicsCommandContext) -> CommandResult?) = apply {
         this.executor = object : BasicsCommandExecutor(module) {
-            override fun execute(context: BasicsCommandContext): Boolean {
+            override fun execute(context: BasicsCommandContext): CommandResult? {
                 return executor(context)
             }
         }
@@ -41,7 +45,12 @@ class BasicsCommandBuilder(private val module: BasicsModule, private val name: S
             usage = usage,
             aliases = aliases,
         )
-        return BasicsCommand(info, executor ?: error("Executor must be set"), module.plugin.messages)
+        return BasicsCommand(
+            info,
+            executor ?: error("Executor must be set"),
+            module.plugin.messages,
+            module.plugin.messageFactory
+        )
     }
 
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandBuilder.kt
@@ -12,12 +12,14 @@ class BasicsCommandBuilder(
 
     private var permissionMessage: Message = module.plugin.messages.noPermission
     private var description: String? = null
-    private var usage: String? = null
+    private var usage: String = ""
     private var aliases: List<String> = emptyList()
     private var executor: BasicsCommandExecutor? = null
 
     fun description(description: String) = apply { this.description = description }
-    fun usage(usage: String) = apply { this.usage = usage }
+    fun usage(usage: String) = apply {
+        if(usage.startsWith("/")) error("Usage should not start with /<command> - only pass the arguments.")
+        this.usage = usage }
     fun permissionMessage(permissionMessage: Message) = apply { this.permissionMessage = permissionMessage }
     fun aliases(aliases: List<String>) = apply { this.aliases = aliases }
     fun executor(executor: BasicsCommandExecutor) = apply { this.executor = executor }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandException.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandException.kt
@@ -1,3 +1,5 @@
 package com.github.spigotbasics.core.command
 
-class BasicsCommandException(message: String): IllegalArgumentException(message)
+class BasicsCommandException(val commandResult: CommandResult): IllegalArgumentException() {
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandExecutor.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandExecutor.kt
@@ -13,7 +13,7 @@ abstract class BasicsCommandExecutor(module: BasicsModule) {
     protected val coreMessages: CoreMessages = module.plugin.messages
     protected val messageFactory: MessageFactory = module.plugin.messageFactory
 
-    abstract fun execute(context: BasicsCommandContext): Boolean
+    abstract fun execute(context: BasicsCommandContext): CommandResult?
 
     open fun tabComplete(context: BasicsCommandContext): MutableList<String>? {
         return null

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandExecutor.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/BasicsCommandExecutor.kt
@@ -25,8 +25,7 @@ abstract class BasicsCommandExecutor(module: BasicsModule) {
     fun requirePlayer(sender: CommandSender, name: String): Player {
         val player = Bukkit.getPlayer(name)
         if(player == null) {
-            coreMessages.playerNotFound(name).sendToSender(sender)
-            throw BasicsCommandException("Player $name not found")
+            throw BasicsCommandException(CommandResult.playerNotFound(name))
         }
         return player
     }
@@ -34,28 +33,16 @@ abstract class BasicsCommandExecutor(module: BasicsModule) {
     @Throws(BasicsCommandException::class)
     fun notFromConsole(sender: CommandSender): Player {
         if(sender !is Player) {
-            coreMessages.commandNotFromConsole.sendToSender(sender)
-            throw BasicsCommandException("Must be player")
+            throw BasicsCommandException(CommandResult.notFromConsole())
         }
         return sender
-    }
-
-    @Throws(BasicsCommandException::class)
-    fun requirePlayerExact(sender: CommandSender, name: String): Player {
-        val player = Bukkit.getPlayerExact(name)
-        if(player == null) {
-            coreMessages.playerNotFound(name).sendToSender(sender)
-            throw BasicsCommandException("Player $name not found")
-        }
-        return player
     }
 
     @Throws(BasicsCommandException::class)
     fun requirePlayerOrMustSpecifyPlayerFromConsole(sender: CommandSender): Player {
         val player = sender as? Player
         if(player == null) {
-            coreMessages.mustSpecifyPlayerFromConsole.sendToSender(sender)
-            throw BasicsCommandException("Must specify player from console")
+            throw BasicsCommandException(CommandResult.mustBePlayerOrSpecifyPlayerFromConsole())
         }
         return player
     }
@@ -63,20 +50,17 @@ abstract class BasicsCommandExecutor(module: BasicsModule) {
     @Throws(BasicsCommandException::class)
     fun failIfFlagsLeft(context: BasicsCommandContext) {
         if(context.flags.isEmpty()) return
-        coreMessages.unknownOption(context.flags[0]).sendToSender(context.sender)
-        throw BasicsCommandException("Unknown option: ${context.flags[0]}")
+        throw BasicsCommandException(CommandResult.unknownFlag(context.flags[0]))
     }
 
     @Throws(BasicsCommandException::class)
-    fun failInvalidArgument(sender: CommandSender, argument: String): Boolean {
-        coreMessages.invalidArgument(argument).sendToSender(sender)
-        throw BasicsCommandException("Invalid argument: $argument")
+    fun failInvalidArgument(argument: String): CommandResult {
+        throw BasicsCommandException(CommandResult.invalidArgument(argument))
     }
 
     fun requirePermission(sender: CommandSender, permission: Permission) {
         if(!sender.hasPermission(permission)) {
-            coreMessages.noPermission(permission).sendToSender(sender)
-            throw BasicsCommandException("${sender.name} does not have permission $permission")
+            throw BasicsCommandException(CommandResult.noPermission(permission))
         }
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandInfo.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandInfo.kt
@@ -12,7 +12,7 @@ data class CommandInfo (
     val permission: Permission,
     val permissionMessage: Message,
     val description: String?,
-    val usage: String?,
+    val usage: String,
     val aliases: List<String>,
     //val executor: (CommandSender, BasicsCommand, String, List<String>) -> Boolean
     //val executor: BasicsCommandExecutor

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandResult.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandResult.kt
@@ -1,28 +1,82 @@
 package com.github.spigotbasics.core.command
 
+import org.bukkit.permissions.Permission
+
 abstract class CommandResult private constructor() {
 
     abstract fun process(context: BasicsCommandContext)
 
     companion object {
+
         val SUCCESS = object : CommandResult() {
             override fun process(context: BasicsCommandContext) {
                 // Do nothing
             }
         }
 
-        fun usage(/*messageFactory: MessageFactory, */usage: String): CommandResult {
+        val USAGE = usage()
+        val NOT_FROM_CONSOLE = notFromConsole()
+        val MUST_BE_PLAYER_OR_SPECIFY_PLAYER_FROM_CONSOLE = mustBePlayerOrSpecifyPlayerFromConsole()
+
+        fun usage(usage: String? = null): CommandResult {
             return object : CommandResult() {
                 override fun process(context: BasicsCommandContext) {
                     context.command.messageFactory
-                        .createMessage(
+                        .createMessage( // TODO: Configurable
                             "<red>Invalid command usage.</red>",
                             "<red>Usage: </red><gold>/<#command> <#usage></gold>"
-                        ).tagParsed("usage", usage).tagParsed("command", context.command.name)
+                        ).tagUnparsed("usage", usage ?: context.command.info.usage).tagUnparsed("command", context.command.name)
                         .sendToSender(context.sender)
                 }
             }
+        }
 
+        fun playerNotFound(name: String): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.playerNotFound(name).sendToSender(context.sender)
+                }
+            }
+        }
+
+        fun notFromConsole(): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.commandNotFromConsole.sendToSender(context.sender)
+                }
+            }
+        }
+
+        fun mustBePlayerOrSpecifyPlayerFromConsole(): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.mustSpecifyPlayerFromConsole.sendToSender(context.sender)
+                }
+            }
+        }
+
+        fun unknownFlag(flag: String): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.unknownOption(flag).sendToSender(context.sender)
+                }
+            }
+        }
+
+        fun invalidArgument(argument: String): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.invalidArgument(argument).sendToSender(context.sender)
+                }
+            }
+        }
+
+        fun noPermission(permission: Permission): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.coreMessages.noPermission(permission).sendToSender(context.sender)
+                }
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandResult.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/CommandResult.kt
@@ -1,0 +1,29 @@
+package com.github.spigotbasics.core.command
+
+abstract class CommandResult private constructor() {
+
+    abstract fun process(context: BasicsCommandContext)
+
+    companion object {
+        val SUCCESS = object : CommandResult() {
+            override fun process(context: BasicsCommandContext) {
+                // Do nothing
+            }
+        }
+
+        fun usage(/*messageFactory: MessageFactory, */usage: String): CommandResult {
+            return object : CommandResult() {
+                override fun process(context: BasicsCommandContext) {
+                    context.command.messageFactory
+                        .createMessage(
+                            "<red>Invalid command usage.</red>",
+                            "<red>Usage: </red><gold>/<#command> <#usage></gold>"
+                        ).tagParsed("usage", usage).tagParsed("command", context.command.name)
+                        .sendToSender(context.sender)
+                }
+            }
+
+        }
+    }
+
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
@@ -1,5 +1,6 @@
 package com.github.spigotbasics.core.messages
 
+import com.github.spigotbasics.core.messages.tags.MESSAGE_SPECIFIC_TAG_PREFIX
 import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 
 
@@ -10,7 +11,7 @@ class MessageFactory(
 
     companion object {
         private const val UNPARSED = "__unparsed__"
-        private const val UNPARSED_TAG = "<$UNPARSED>"
+        private const val UNPARSED_TAG = "<${MESSAGE_SPECIFIC_TAG_PREFIX}${UNPARSED}>"
     }
 
     fun createMessage(vararg text: String): Message {

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/MessageFactory.kt
@@ -13,8 +13,8 @@ class MessageFactory(
         private const val UNPARSED_TAG = "<$UNPARSED>"
     }
 
-    fun createMessage(text: String): Message {
-        return Message(listOf(text), audienceProvider, tagResolverFactory)
+    fun createMessage(vararg text: String): Message {
+        return Message(text.asList(), audienceProvider, tagResolverFactory)
     }
 
     fun createPlainMessage(text: String): Message {

--- a/core/src/test/kotlin/com/github/spigotbasics/core/util/Knef.kt
+++ b/core/src/test/kotlin/com/github/spigotbasics/core/util/Knef.kt
@@ -1,0 +1,9 @@
+package com.github.spigotbasics.core.util
+
+private const val KNEF = "_Knef"
+private val `🗺️` = mutableMapOf<Int, String>()
+private val `reverse🗺️` = mutableMapOf<String, Int>()
+
+fun String.normalize() = `reverse🗺️`.computeIfAbsent(this) { `🗺️`.size.also { `🗺️`[it] = this } }
+
+fun Int.denormalize() = `🗺️`.getOrDefault(this, KNEF)

--- a/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BasicsBroadcastModule.kt
+++ b/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BasicsBroadcastModule.kt
@@ -11,7 +11,7 @@ class BasicsBroadcastModule(context: ModuleInstantiationContext) : AbstractBasic
     override fun onEnable() {
         createCommand("broadcast", commandPerm)
             .description("Broadcasts a message to all players")
-            .usage("/broadcast [--parsed] <message>")
+            .usage("[--parsed] <message>")
             .executor(BroadcastExecutor(this))
             .register()
     }

--- a/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BroadcastExecutor.kt
+++ b/modules/basics-broadcast/src/main/kotlin/com/github/spigotbasics/modules/basicsbroadcast/BroadcastExecutor.kt
@@ -2,11 +2,12 @@ package com.github.spigotbasics.modules.basicsbroadcast
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
 
 class BroadcastExecutor(private val module: BasicsBroadcastModule) : BasicsCommandExecutor(module) {
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
 
         context.readFlags()
 
@@ -25,7 +26,7 @@ class BroadcastExecutor(private val module: BasicsBroadcastModule) : BasicsComma
 
         message.sendToAllPlayers()
         message.sendToConsole()
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String> {

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
@@ -13,7 +13,7 @@ class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModu
     )
 
     override fun onEnable() {
-        createCommand("module", permission).usage("/module [command]").executor(ModulesCommand(this)).register()
+        createCommand("module", permission).usage("<command>").executor(ModulesCommand(this)).register()
     }
 
 }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/ModulesCommand.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/ModulesCommand.kt
@@ -62,7 +62,7 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
             "unload" -> return unloadModule(sender, requireModule(sender, args[0]))
             "load" -> return loadModule(sender, context)
             else -> {
-                failInvalidArgument(sender, subCommand)
+                failInvalidArgument(subCommand)
             }
         }
 
@@ -72,7 +72,7 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
 
     private fun showInfo(sender: CommandSender, module: BasicsModule): CommandResult {
         val provider = ModuleTagProvider(module)
-        val message = messageFactory.createMessage(listOf(
+        messageFactory.createMessage(listOf(
             "<gold>Module Info:</gold>",
             "<gold>Name:</gold> <gray><#module></gray>",
             "<gold>Version:</gold> <gray><#version></gray>",
@@ -105,7 +105,7 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
         return CommandResult.SUCCESS
     }
 
-    private fun unloadModule(sender: CommandSender, module: BasicsModule): Boolean {
+    private fun unloadModule(sender: CommandSender, module: BasicsModule): CommandResult {
         if(module.isEnabled()) {
             moduleManager.disableModule(module).get() // TODO: This is blocking, but it shouldn't be
             messageFactory.createMessage("<gold>Module ${module.info.name} <red>disabled</red>.</gold>")
@@ -113,30 +113,30 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
         }
         moduleManager.unloadModule(module, true)
         messageFactory.createMessage("<gold>Module ${module.info.name} <red><bold>UNLOADED</bold></red>.</gold>").sendToSender(sender)
-        return true
+        return CommandResult.SUCCESS
     }
 
     private fun requireModule(sender: CommandSender, arg: String): BasicsModule {
         val module = moduleManager.getModule(arg)
         if (module == null) {
             messageFactory.createMessage("<red>Module $arg not found").sendToSender(sender)
-            throw BasicsCommandException("Module $arg not found")
+            throw BasicsCommandException(CommandResult.SUCCESS)
         }
         return module
     }
 
-    private fun reloadModule(sender: CommandSender, module: BasicsModule): Boolean {
+    private fun reloadModule(sender: CommandSender, module: BasicsModule): CommandResult {
         if (!module.isEnabled()) {
             messageFactory.createMessage("<red>Module ${module.info.name} is not enabled.</red>").sendToSender(sender)
-            return true
+            return CommandResult.SUCCESS
         }
         module.reloadConfig()
         messageFactory.createMessage("<gold>Module ${module.info.name} <green>reloaded</green>.</gold>")
             .sendToSender(sender)
-        return true
+        return CommandResult.SUCCESS
     }
 
-    private fun reloadJar(sender: CommandSender, module: BasicsModule): Boolean {
+    private fun reloadJar(sender: CommandSender, module: BasicsModule): CommandResult {
         val enable = module.isEnabled()
         val file = module.file
         unloadModule(sender, module)
@@ -153,7 +153,7 @@ class ModulesCommand(val module: BasicsCoreModule) : BasicsCommandExecutor(modul
             enableModule(sender, result.getOrThrow())
         }
 
-        return true
+        return CommandResult.SUCCESS
 
     }
 

--- a/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/BasicsGamemodeModule.kt
+++ b/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/BasicsGamemodeModule.kt
@@ -34,7 +34,7 @@ class BasicsGamemodeModule(context: ModuleInstantiationContext) : AbstractBasics
     override fun onEnable() {
         createCommand("gamemode", perm)
             .description("Changes the player's game mode")
-            .usage("/gamemode <mode> [player]")
+            .usage("<mode> [player]")
             .executor(GamemodeExecutor(this))
             .register()
     }

--- a/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/GamemodeExecutor.kt
+++ b/modules/basics-gamemode/src/main/kotlin/com/github/spigotbasics/modules/basicsgamemode/GamemodeExecutor.kt
@@ -2,24 +2,25 @@ package com.github.spigotbasics.modules.basicsgamemode
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
 
 class GamemodeExecutor(val module: BasicsGamemodeModule) : BasicsCommandExecutor(module) {
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         val args = context.args
         val sender = context.sender
         var target: Player
 
         if(args.isEmpty() || args.size > 2) {
-            return false
+            return CommandResult.USAGE
         }
 
         val gameModeName = args[0]
         val gameMode = module.toGameMode(gameModeName)
         if(gameMode == null) {
-            return failInvalidArgument(sender, gameModeName)
+            return failInvalidArgument(gameModeName)
         }
 
         requirePermission(sender, module.getPermission(gameMode))
@@ -30,7 +31,7 @@ class GamemodeExecutor(val module: BasicsGamemodeModule) : BasicsCommandExecutor
             requirePermission(sender, module.permOthers)
             target = requirePlayer(sender, args[1])
         } else {
-            return false
+            return CommandResult.USAGE
         }
 
         target.gameMode = gameMode
@@ -40,7 +41,7 @@ class GamemodeExecutor(val module: BasicsGamemodeModule) : BasicsCommandExecutor
             .concerns(target)
 
         message.sendToSender(sender)
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String>? {

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/BasicsHomesModule.kt
@@ -44,25 +44,25 @@ class BasicsHomesModule(context: ModuleInstantiationContext) : AbstractBasicsMod
 
         createCommand("home", permissionHome)
             .description("Teleports you to one of your homes")
-            .usage("/home [name]")
+            .usage("[name]")
             .executor(HomeCommand(this))
             .register()
 
         createCommand("homes", permissionHome)
             .description("Lists your homes")
-            .usage("/homes")
+            //.usage("/homes")
             .executor(HomeListCommand(this))
             .register()
 
         createCommand("sethome", permissionSetHome)
             .description("Sets a home")
-            .usage("/sethome [name]")
+            .usage("[name]")
             .executor(SetHomeCommand(this))
             .register()
 
         createCommand("delhome", permissionDelHome)
             .description("Deletes a home")
-            .usage("/delhome [name]")
+            .usage("[name]")
             .executor(DelHomeCommand(this))
             .register()
     }

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/DelHomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/DelHomeCommand.kt
@@ -3,6 +3,7 @@ package com.github.spigotbasics.modules.basicshomes.commands
 import com.github.spigotbasics.common.Either
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.modules.basicshomes.BasicsHomesModule
 import org.bukkit.entity.Player
@@ -11,10 +12,10 @@ class DelHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
 
     private val messages = module.messages
 
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         val result = module.parseHomeCmd(context)
         if(result is Either.Right) {
-            return result.value
+            return if(result.value) CommandResult.SUCCESS else CommandResult.USAGE
         }
 
         val home = (result as Either.Left).value
@@ -22,7 +23,7 @@ class DelHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
 
         module.getHomeList(player.uniqueId).removeHome(home)
         messages.homeDeleted(home).sendToSender(player)
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String> {

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeCommand.kt
@@ -4,6 +4,7 @@ import com.github.spigotbasics.common.Either
 import com.github.spigotbasics.core.Spiper
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.exceptions.WorldNotLoadedException
 import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.core.model.toLocation
@@ -15,10 +16,10 @@ class HomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecutor
 
     private val messages = module.messages
 
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         val result = module.parseHomeCmd(context)
         if(result is Either.Right) {
-            return result.value
+            return if(result.value) CommandResult.SUCCESS else CommandResult.USAGE
         }
 
         val home = (result as Either.Left).value
@@ -30,7 +31,7 @@ class HomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecutor
         } catch (e: WorldNotLoadedException) {
             messages.homeWorldNotLoaded(home.location.world).sendToSender(player)
         }
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String> {

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeListCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/HomeListCommand.kt
@@ -2,7 +2,9 @@ package com.github.spigotbasics.modules.basicshomes.commands
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.messages.Message
+import com.github.spigotbasics.core.messages.tags.MESSAGE_SPECIFIC_TAG_PREFIX
 import com.github.spigotbasics.modules.basicshomes.BasicsHomesModule
 import com.github.spigotbasics.modules.basicshomes.data.Home
 
@@ -10,7 +12,8 @@ class HomeListCommand(private val module: BasicsHomesModule) : BasicsCommandExec
 
     private val messages = module.messages
 
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
+        if(context.args.isNotEmpty()) return CommandResult.USAGE
         val player = notFromConsole(context.sender)
         val homeList = module.getHomeList(player.uniqueId).toList()
         if (homeList.isEmpty()) {
@@ -19,7 +22,7 @@ class HomeListCommand(private val module: BasicsHomesModule) : BasicsCommandExec
             allHomes2msg(homeList).sendToSender(player)
         }
 
-        return true
+        return CommandResult.SUCCESS
     }
 
     fun home2msg(home: Home) =
@@ -28,7 +31,7 @@ class HomeListCommand(private val module: BasicsHomesModule) : BasicsCommandExec
 
     fun allHomes2msg(homes: List<Home>): Message {
         val messageList =
-            messageFactory.createMessage(List(homes.size) { index -> "<#home${index + 1}>" }.joinToString("<#separator>"))
+            messageFactory.createMessage(List(homes.size) { index -> "<${MESSAGE_SPECIFIC_TAG_PREFIX}home${index + 1}>" }.joinToString("<#separator>"))
 
         homes.mapIndexed() { index, home -> messageList.tagMessage("home${index + 1}", home2msg(home)) }
         messageList.tagMessage("separator", messages.homeListSeparator)

--- a/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/SetHomeCommand.kt
+++ b/modules/basics-homes/src/main/kotlin/com/github/spigotbasics/modules/basicshomes/commands/SetHomeCommand.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.modules.basicshomes.commands
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.extensions.getPermissionNumberValue
 import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.modules.basicshomes.BasicsHomesModule
@@ -12,16 +13,15 @@ class SetHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
 
     private val messages = module.messages
 
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         if (context.sender !is Player) {
-            module.plugin.messages.commandNotFromConsole.sendToSender(context.sender)
-            return true
+            return CommandResult.NOT_FROM_CONSOLE
         }
 
         var homeName = "home"
 
         if (context.args.size > 1) {
-            return false
+            return CommandResult.USAGE
         }
 
         val player = context.sender as Player
@@ -49,7 +49,7 @@ class SetHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
                     messages.homeLimitReached(1)
                         .sendToSender(player)
 
-                    return true
+                    return CommandResult.SUCCESS
                 }
             }
 
@@ -64,19 +64,19 @@ class SetHomeCommand(private val module: BasicsHomesModule) : BasicsCommandExecu
 
         if (!isOkay) {
             messages.homeLimitReached(maxAllowed).sendToSender(player)
-            return true
+            return CommandResult.SUCCESS
         }
 
         if(!homeName.matches(module.regex.toRegex())) {
             messages.homeInvalidName(module.regex).sendToSender(player)
-            return true
+            return CommandResult.SUCCESS
         }
 
         val home = Home(homeName, location)
 
         homeList.addHome(home)
         messages.homeSet(home).sendToSender(player)
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String> {

--- a/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/BasicsMsgModule.kt
+++ b/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/BasicsMsgModule.kt
@@ -28,7 +28,7 @@ class BasicsMsgModule(context: ModuleInstantiationContext) : AbstractBasicsModul
     override fun onEnable() {
         createCommand("msg", permission)
             .description("Sends a private message to another player")
-            .usage("/msg <player> <message>")
+            .usage("<player> <message>")
             .executor(MsgExecutor(this))
             .register()
     }

--- a/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/MsgExecutor.kt
+++ b/modules/basics-msg/src/main/kotlin/com/github/spigotbasics/modules/basicsmsg/MsgExecutor.kt
@@ -2,14 +2,15 @@ package com.github.spigotbasics.modules.basicsmsg
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
 class MsgExecutor(private val module: BasicsMsgModule) : BasicsCommandExecutor(module) {
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         val sender = context.sender
         if(context.args.size < 2) {
-            return false
+            return CommandResult.USAGE
         }
         val player = requirePlayer(sender, context.args[0])
         val message = context.args.drop(1).joinToString(" ")
@@ -22,7 +23,7 @@ class MsgExecutor(private val module: BasicsMsgModule) : BasicsCommandExecutor(m
         } else {
             console2player(sender, player, message)
         }
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String>? {

--- a/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/BasicsRepairModule.kt
+++ b/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/BasicsRepairModule.kt
@@ -27,7 +27,7 @@ class BasicsRepairModule(context: ModuleInstantiationContext) : AbstractBasicsMo
 
     override fun onEnable() {
         createCommand("repair", permission)
-            .usage("/repair [--all] [player]")
+            .usage("[--all] [player]")
             .description("Repairs an item")
             .executor(RepairCommand(this))
             .register()

--- a/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/RepairCommand.kt
+++ b/modules/basics-repair/src/main/kotlin/com/github/spigotbasics/modules/basicsrepair/RepairCommand.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.modules.basicsrepair
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.command.TabCompleter
 import com.github.spigotbasics.core.extensions.startsWithIgnoreCase
 import org.bukkit.command.CommandSender
@@ -12,7 +13,7 @@ import org.bukkit.util.StringUtil
 
 class RepairCommand(private val module: BasicsRepairModule) : BasicsCommandExecutor(module) {
 
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         context.readFlags()
         val args = context.args
         val repairAll = context.popFlag("--all")
@@ -45,7 +46,7 @@ class RepairCommand(private val module: BasicsRepairModule) : BasicsCommandExecu
             }
         }
 
-        return true
+        return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String>? {

--- a/modules/basics-workbench/src/main/kotlin/com/github/spigotbasics/modules/basicsworkbench/BasicsWorkbenchModule.kt
+++ b/modules/basics-workbench/src/main/kotlin/com/github/spigotbasics/modules/basicsworkbench/BasicsWorkbenchModule.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.modules.basicsworkbench
 
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.module.AbstractBasicsModule
 import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.entity.Player
@@ -17,16 +18,15 @@ class BasicsWorkbenchModule(context: ModuleInstantiationContext) : AbstractBasic
         createCommand("workbench", permission)
             .description("Opens a workbench")
             .aliases(listOf("craft"))
-            .usage("/workbench")
             .executor(WorkbenchExecutor())
             .register()
     }
 
     inner class WorkbenchExecutor : BasicsCommandExecutor(this@BasicsWorkbenchModule) {
-        override fun execute(context: BasicsCommandContext): Boolean {
+        override fun execute(context: BasicsCommandContext): CommandResult {
             val player = notFromConsole(context.sender)
             player.openWorkbench(null, true)
-            return true
+            return CommandResult.SUCCESS
         }
     }
 

--- a/modules/basics-world/src/main/kotlin/com/github/spigotbasics/modules/basicsworld/BasicsWorldModule.kt
+++ b/modules/basics-world/src/main/kotlin/com/github/spigotbasics/modules/basicsworld/BasicsWorldModule.kt
@@ -23,7 +23,7 @@ class BasicsWorldModule(context: ModuleInstantiationContext) : AbstractBasicsMod
 
     override fun onEnable() {
         createCommand("world", permission)
-            .usage("/world <world>")
+            .usage("<world>")
             .description("Teleport to another world")
             .executor(WorldCommand(this))
             .register()

--- a/modules/basics-world/src/main/kotlin/com/github/spigotbasics/modules/basicsworld/WorldCommand.kt
+++ b/modules/basics-world/src/main/kotlin/com/github/spigotbasics/modules/basicsworld/WorldCommand.kt
@@ -3,6 +3,7 @@ package com.github.spigotbasics.modules.basicsworld
 import com.github.spigotbasics.core.Spiper
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
 import com.github.spigotbasics.core.extensions.addAnd
 import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.core.util.TeleportUtils
@@ -13,11 +14,11 @@ import org.bukkit.permissions.Permissible
 import java.util.logging.Level
 
 class WorldCommand(val module: BasicsWorldModule) : BasicsCommandExecutor(module) {
-    override fun execute(context: BasicsCommandContext): Boolean {
+    override fun execute(context: BasicsCommandContext): CommandResult {
         val player = notFromConsole(context.sender)
         val args = context.args
         if (args.isEmpty()) {
-            return false
+            return CommandResult.USAGE
         }
 
         context.readFlags()
@@ -27,12 +28,12 @@ class WorldCommand(val module: BasicsWorldModule) : BasicsCommandExecutor(module
         val newWorld = getWorld(args[0])
         if (newWorld == null) {
             coreMessages.worldNotFound(args[0]).sendToSender(player)
-            return true
+            return CommandResult.SUCCESS // TODO: CommandResult.worldNotFound(String)
         }
 
         if (newWorld == origin.world) {
             module.msgAlreadyInWorld(newWorld.name).sendToSender(player)
-            return true
+            return CommandResult.SUCCESS
         }
 
         val translatedTargetLocation = TeleportUtils.getScaledLocationInOtherWorld(origin, newWorld)
@@ -41,7 +42,7 @@ class WorldCommand(val module: BasicsWorldModule) : BasicsCommandExecutor(module
 
         if (force) {
             Spiper.teleportAsync(player, translatedTargetLocation)
-            return true
+            return CommandResult.SUCCESS
         }
 
         val future = TeleportUtils.findSafeLocationInSameChunkAsync(
@@ -81,7 +82,7 @@ class WorldCommand(val module: BasicsWorldModule) : BasicsCommandExecutor(module
         }
 
         module.msgStartingTeleport(newWorld.name).sendToPlayerActionBar(player)
-        return true
+        return CommandResult.SUCCESS
     }
 
     fun getWorld(name: String): World? {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core"))
+    implementation(project(":core", "shadow"))
     implementation(project(":pipe:facade"))
     implementation(project(":pipe:spigot"))
     implementation(project(":pipe:paper"))


### PR DESCRIPTION
CommandResults have a proccess(BasicsCommandContext) method that gets executed after the command ran, making it easy to return reusable command results such as "invalid argument: <args>", etc