### PR TITLE
Add "setcolor" command to chat-format module

### DIFF
--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
@@ -1,30 +1,73 @@
 package com.github.spigotbasics.modules.basicschatformat
 
+import com.github.spigotbasics.core.Serialization
 import com.github.spigotbasics.core.Spiper
+import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.extensions.getAsNewLineSeparatedString
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.AbstractBasicsModule
 import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
+import com.github.spigotbasics.core.storage.NamespacedStorage
+import com.github.spigotbasics.modules.basicschatformat.commmands.ColorChatCommand
+import com.github.spigotbasics.modules.basicschatformat.data.ChatData
 import org.bukkit.event.EventPriority
 import org.bukkit.event.player.AsyncPlayerChatEvent
+import java.util.UUID
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.logging.Level
 
 private fun String.escapeFormat(): String {
     return this.replace("%", "%%")
 }
 
 class BasicsChatFormatModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
+    private var storage: NamespacedStorage? = null
+    private val chatData = mutableMapOf<UUID, ChatData>()
+    override val messages = getConfig(ConfigName.MESSAGES, Messages::class.java)
+
+    val permissionSetColor =
+        permissionManager.createSimplePermission("basics.setcolor", "Allows access to the /setcolor command")
+
     val format: Message
         get() = config.getMessage("chat-format")
 
+    val messageColor: String get() = config.getString("message-color", "white")!!
+
+    val regex: Regex
+        get() =
+            Regex(
+                config.getString(
+                    "regex-whitelist",
+                    config.getString(
+                        "regex-blacklist",
+                        "\\b(bold|b|italic|em|i|underlined|u|strikethrough|st|obfuscated|obf)\\b",
+                    )!!,
+                )!!,
+            )
     val formatAsStr: String
         get() = config.getAsNewLineSeparatedString("chat-format")
 
     override fun onEnable() {
+        storage = createStorage()
+
         if (Spiper.isPaper) {
             eventBus.subscribe(PaperChatEventListener(this))
         } else {
             eventBus.subscribe(AsyncPlayerChatEvent::class.java, this::changeChatFormatSpigot, EventPriority.HIGHEST)
         }
+
+        createCommand("setcolor", permissionSetColor)
+            .description("Sets your chat color")
+            .usage("[color]")
+            .executor(ColorChatCommand(this))
+            .register()
+    }
+
+    override fun reloadConfig() {
+        config.reload()
+        messages.reload()
     }
 
     fun changeChatFormatSpigot(event: AsyncPlayerChatEvent) {
@@ -32,6 +75,47 @@ class BasicsChatFormatModule(context: ModuleInstantiationContext) : AbstractBasi
             format
                 .concerns(event.player)
                 .tagUnparsed("message", event.message) // TODO: To allow MiniMessage in chat, this should be parsed.
+                .tagParsed("message-color", "<${getChatData(event.player.uniqueId).color}>")
                 .toLegacyString().escapeFormat()
+    }
+
+    fun getChatData(uuid: UUID): ChatData {
+        return chatData[uuid] ?: error("chat data is null")
+    }
+
+    override fun loadPlayerData(uuid: UUID): CompletableFuture<Void?> =
+        CompletableFuture.runAsync {
+            chatData[uuid] = loadPlayerDataBlocking(uuid)
+        }
+
+    override fun savePlayerData(uuid: UUID): CompletableFuture<Void?> =
+        CompletableFuture.runAsync {
+            val chatDatum = chatData[uuid] ?: error("Homes is null")
+            val storage = storage ?: error("Storage is null")
+            try {
+                storage.setJsonElement(uuid.toString(), Serialization.toJson(chatDatum)).join()
+            } catch (exception: CompletionException) {
+                logger.log(Level.SEVERE, "Failed to save chat data for $uuid", exception)
+            } catch (exception: CancellationException) {
+                logger.log(Level.SEVERE, "Failed to save chat data for $uuid", exception)
+            }
+        }
+
+    override fun forgetPlayerData(uuid: UUID) {
+        chatData.remove(uuid)
+    }
+
+    private fun loadPlayerDataBlocking(uuid: UUID): ChatData {
+        val storage = storage ?: error("Storage is null")
+        try {
+            val json = storage.getJsonElement(uuid.toString()).join() ?: return ChatData(messageColor)
+            return Serialization.fromJson(json, ChatData::class.java)
+        } catch (exception: CompletionException) {
+            logger.log(Level.SEVERE, "Failed to load chat data for $uuid", exception)
+        } catch (exception: CancellationException) {
+            logger.log(Level.SEVERE, "Failed to load chat data for $uuid", exception)
+        }
+
+        return ChatData(messageColor)
     }
 }

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
@@ -1,0 +1,15 @@
+package com.github.spigotbasics.modules.basicschatformat
+
+import com.github.spigotbasics.core.config.ConfigInstantiationContext
+import com.github.spigotbasics.core.config.SavedConfig
+
+class Messages(context: ConfigInstantiationContext) : SavedConfig(context) {
+    fun colorSet(color: String) =
+        getMessage("color-set")
+            .tagParsed("selected-color-parsed", "<$color>")
+            .tagUnparsed("selected-color-name", color)
+
+    fun colorInvalid(color: String) =
+        getMessage("color-invalid")
+            .tagUnparsed("selected-color-name", color)
+}

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
@@ -26,6 +26,7 @@ class PaperChatEventListener(private val module: BasicsChatFormatModule) : Liste
         val serialized =
             module.format.concerns(player)
                 .tagMiniMessage("message", SerializedMiniMessage(mini.serialize(message)))
+                .tagParsed("message-color", "<${module.getChatData(player.uniqueId).color}>")
                 .serialize()
         val component = NativeComponentConverter.toNativeComponent(serialized)
         return component

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
@@ -1,0 +1,42 @@
+package com.github.spigotbasics.modules.basicschatformat.commmands
+
+import com.github.spigotbasics.core.command.BasicsCommandContext
+import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
+import com.github.spigotbasics.modules.basicschatformat.BasicsChatFormatModule
+import net.md_5.bungee.api.ChatColor
+import org.bukkit.entity.Player
+import java.util.Arrays
+import java.util.stream.Collectors
+
+class ColorChatCommand(private val module: BasicsChatFormatModule) : BasicsCommandExecutor(module) {
+    override fun execute(context: BasicsCommandContext): CommandResult {
+        if (context.sender !is Player) {
+            module.plugin.messages.commandNotFromConsole.sendToSender(context.sender)
+            return CommandResult.SUCCESS
+        }
+        val player = context.sender as Player
+
+        var color = module.messageColor
+        if (context.args.size == 1) {
+            color = context.args[0]
+        } else if (context.args.size > 1) {
+            return CommandResult.USAGE
+        }
+
+        if (color != module.messageColor && !module.regex.matches(color)) {
+            module.messages.colorInvalid(color).sendToSender(player)
+            return CommandResult.SUCCESS
+        }
+
+        val chatDatum = module.getChatData(player.uniqueId)
+        chatDatum.color = color
+        module.messages.colorSet(color).sendToSender(player)
+
+        return CommandResult.SUCCESS
+    }
+
+    override fun tabComplete(context: BasicsCommandContext): MutableList<String> {
+        return Arrays.stream(ChatColor.values()).map { it.name }.collect(Collectors.toList())
+    }
+}

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
@@ -1,0 +1,3 @@
+package com.github.spigotbasics.modules.basicschatformat.data
+
+class ChatData(var color: String)

--- a/modules/basics-chat-format/src/main/resources/config.yml
+++ b/modules/basics-chat-format/src/main/resources/config.yml
@@ -1,2 +1,8 @@
-# Tags: <#message>
-chat-format: "<player-dm> <dark_text>»<reset> <#message>"
+# Tags: <#message> <#message-color>
+chat-format: "<player-dm> <dark_text>»<reset> <#message-color><#message>"
+message-color: "<white>"
+
+# Color names that match this regex will be blacklisted
+regex-blacklist: "^(?!\\bbold\\b|\\bb\\b|\\bitalic\\b|\\bem\\b|\\bi\\b|\\bunderlined\\b|\\bu\\b|\\bstrikethrough\\b|\\bst\\b|\\bobfuscated\\b|\\bobf\\b).*$"
+# Color names that match this regex are whitelisted | when in use blacklist is ignored | Comment out to turn off
+regex-whitelist: "(\\b(black|dark_blue|dark_green|dark_red|dark_purple|gold|gray|dark_gray|blue|green|aqua|red|light_purple|yellow|white)\\b|#[0-9a-fA-F]{6}|gradient:#[0-9a-fA-F]{6}:#[0-9a-fA-F]{6})"

--- a/modules/basics-chat-format/src/main/resources/messages.yml
+++ b/modules/basics-chat-format/src/main/resources/messages.yml
@@ -1,0 +1,4 @@
+# Tags: <#selected-color-name>, <#selected-color-parsed>
+color-set: "<def_text>Set your chat color to <#selected-color-parsed><#selected-color-name>!</def_text>"
+# Tags: <#selected-color-name>
+color-invalid: "<error><error_red>The given color name <bright_red><#selected-color-name></bright_red> is invalid</error_red>"


### PR DESCRIPTION
The goal is to allow players to use color chat. I added configurable options in the basics-chat-format-config.yml and added a basics-chat-format-messages.yml to manage messages.

Example Video

[Screencast from 2024-02-10 11-17-41.webm](https://github.com/SpigotBasics/basics/assets/81843550/5a3b9261-48b1-4867-8d7e-6ccd9f3ddd43)

To Configure "Valid" and "Invalid" statements both a blacklist-regex and whitelist-regex are provided. They preform inverted tasks