### PR TITLE
Y2 kwastaken chatcolors

### DIFF
--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/BasicsChatFormatModule.kt
@@ -1,30 +1,73 @@
 package com.github.spigotbasics.modules.basicschatformat
 
+import com.github.spigotbasics.core.Serialization
 import com.github.spigotbasics.core.Spiper
+import com.github.spigotbasics.core.config.ConfigName
 import com.github.spigotbasics.core.extensions.getAsNewLineSeparatedString
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.module.AbstractBasicsModule
 import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
+import com.github.spigotbasics.core.storage.NamespacedStorage
+import com.github.spigotbasics.modules.basicschatformat.commmands.ColorChatCommand
+import com.github.spigotbasics.modules.basicschatformat.data.ChatData
 import org.bukkit.event.EventPriority
 import org.bukkit.event.player.AsyncPlayerChatEvent
+import java.util.UUID
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.logging.Level
 
 private fun String.escapeFormat(): String {
     return this.replace("%", "%%")
 }
 
 class BasicsChatFormatModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
+    private var storage: NamespacedStorage? = null
+    private val chatData = mutableMapOf<UUID, ChatData>()
+    override val messages = getConfig(ConfigName.MESSAGES, Messages::class.java)
+
+    val permissionSetColor =
+        permissionManager.createSimplePermission("basics.setcolor", "Allows access to the /setcolor command")
+
     val format: Message
         get() = config.getMessage("chat-format")
 
+    val messageColor: String get() = config.getString("message-color", "white")!!
+
+    val regex: Regex
+        get() =
+            Regex(
+                config.getString(
+                    "regex-whitelist",
+                    config.getString(
+                        "regex-blacklist",
+                        "\\b(bold|b|italic|em|i|underlined|u|strikethrough|st|obfuscated|obf)\\b",
+                    )!!,
+                )!!,
+            )
     val formatAsStr: String
         get() = config.getAsNewLineSeparatedString("chat-format")
 
     override fun onEnable() {
+        storage = createStorage()
+
         if (Spiper.isPaper) {
             eventBus.subscribe(PaperChatEventListener(this))
         } else {
             eventBus.subscribe(AsyncPlayerChatEvent::class.java, this::changeChatFormatSpigot, EventPriority.HIGHEST)
         }
+
+        createCommand("setcolor", permissionSetColor)
+            .description("Sets your chat color")
+            .usage("[color]")
+            .executor(ColorChatCommand(this))
+            .register()
+    }
+
+    override fun reloadConfig() {
+        config.reload()
+        messages.reload()
     }
 
     fun changeChatFormatSpigot(event: AsyncPlayerChatEvent) {
@@ -32,6 +75,47 @@ class BasicsChatFormatModule(context: ModuleInstantiationContext) : AbstractBasi
             format
                 .concerns(event.player)
                 .tagUnparsed("message", event.message) // TODO: To allow MiniMessage in chat, this should be parsed.
+                .tagParsed("message-color", "<${getChatData(event.player.uniqueId).color}>")
                 .toLegacyString().escapeFormat()
+    }
+
+    fun getChatData(uuid: UUID): ChatData {
+        return chatData[uuid] ?: error("chat data is null")
+    }
+
+    override fun loadPlayerData(uuid: UUID): CompletableFuture<Void?> =
+        CompletableFuture.runAsync {
+            chatData[uuid] = loadPlayerDataBlocking(uuid)
+        }
+
+    override fun savePlayerData(uuid: UUID): CompletableFuture<Void?> =
+        CompletableFuture.runAsync {
+            val chatDatum = chatData[uuid] ?: error("Homes is null")
+            val storage = storage ?: error("Storage is null")
+            try {
+                storage.setJsonElement(uuid.toString(), Serialization.toJson(chatDatum)).join()
+            } catch (exception: CompletionException) {
+                logger.log(Level.SEVERE, "Failed to save chat data for $uuid", exception)
+            } catch (exception: CancellationException) {
+                logger.log(Level.SEVERE, "Failed to save chat data for $uuid", exception)
+            }
+        }
+
+    override fun forgetPlayerData(uuid: UUID) {
+        chatData.remove(uuid)
+    }
+
+    private fun loadPlayerDataBlocking(uuid: UUID): ChatData {
+        val storage = storage ?: error("Storage is null")
+        try {
+            val json = storage.getJsonElement(uuid.toString()).join() ?: return ChatData(messageColor)
+            return Serialization.fromJson(json, ChatData::class.java)
+        } catch (exception: CompletionException) {
+            logger.log(Level.SEVERE, "Failed to load chat data for $uuid", exception)
+        } catch (exception: CancellationException) {
+            logger.log(Level.SEVERE, "Failed to load chat data for $uuid", exception)
+        }
+
+        return ChatData(messageColor)
     }
 }

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
@@ -12,4 +12,6 @@ class Messages(context: ConfigInstantiationContext) : SavedConfig(context) {
     fun colorInvalid(color: String) =
         getMessage("color-invalid")
             .tagUnparsed("selected-color-name", color)
+
+    val colorReset get() = getMessage("color-reset")
 }

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/Messages.kt
@@ -1,0 +1,15 @@
+package com.github.spigotbasics.modules.basicschatformat
+
+import com.github.spigotbasics.core.config.ConfigInstantiationContext
+import com.github.spigotbasics.core.config.SavedConfig
+
+class Messages(context: ConfigInstantiationContext) : SavedConfig(context) {
+    fun colorSet(color: String) =
+        getMessage("color-set")
+            .tagParsed("selected-color-parsed", "<$color>")
+            .tagUnparsed("selected-color-name", color)
+
+    fun colorInvalid(color: String) =
+        getMessage("color-invalid")
+            .tagUnparsed("selected-color-name", color)
+}

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
@@ -26,6 +26,7 @@ class PaperChatEventListener(private val module: BasicsChatFormatModule) : Liste
         val serialized =
             module.format.concerns(player)
                 .tagMiniMessage("message", SerializedMiniMessage(mini.serialize(message)))
+                .tagParsed("message-color", "<${module.getChatData(player.uniqueId).color}>")
                 .serialize()
         val component = NativeComponentConverter.toNativeComponent(serialized)
         return component

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/PaperChatEventListener.kt
@@ -26,7 +26,7 @@ class PaperChatEventListener(private val module: BasicsChatFormatModule) : Liste
         val serialized =
             module.format.concerns(player)
                 .tagMiniMessage("message", SerializedMiniMessage(mini.serialize(message)))
-                .tagParsed("message-color", "<${module.getChatData(player.uniqueId).color}>")
+                .tagParsed("message-color", "<${module.getChatDataOrDefault(player.uniqueId).color}>")
                 .serialize()
         val component = NativeComponentConverter.toNativeComponent(serialized)
         return component

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
@@ -3,11 +3,15 @@ package com.github.spigotbasics.modules.basicschatformat.commmands
 import com.github.spigotbasics.core.command.BasicsCommandContext
 import com.github.spigotbasics.core.command.BasicsCommandExecutor
 import com.github.spigotbasics.core.command.CommandResult
+import com.github.spigotbasics.core.extensions.addAnd
+import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.modules.basicschatformat.BasicsChatFormatModule
+import com.github.spigotbasics.modules.basicschatformat.data.ChatData
 import net.md_5.bungee.api.ChatColor
 import org.bukkit.entity.Player
 import java.util.Arrays
 import java.util.stream.Collectors
+import kotlin.streams.toList
 
 class ColorChatCommand(private val module: BasicsChatFormatModule) : BasicsCommandExecutor(module) {
     override fun execute(context: BasicsCommandContext): CommandResult {
@@ -17,10 +21,17 @@ class ColorChatCommand(private val module: BasicsChatFormatModule) : BasicsComma
         }
         val player = context.sender as Player
 
-        var color = module.messageColor
+        val color: String
         if (context.args.size == 1) {
+
+            if(context.args[0].equals("reset", ignoreCase = true)) {
+                module.resetChatColor(player.uniqueId)
+                module.messages.colorReset.sendToSender(player)
+                return CommandResult.SUCCESS
+            }
+
             color = context.args[0]
-        } else if (context.args.size > 1) {
+        } else  {
             return CommandResult.USAGE
         }
 
@@ -29,14 +40,19 @@ class ColorChatCommand(private val module: BasicsChatFormatModule) : BasicsComma
             return CommandResult.SUCCESS
         }
 
-        val chatDatum = module.getChatData(player.uniqueId)
-        chatDatum.color = color
+        val chatDatum = ChatData(color)
+        module.setChatData(player.uniqueId, chatDatum)
         module.messages.colorSet(color).sendToSender(player)
 
         return CommandResult.SUCCESS
     }
 
     override fun tabComplete(context: BasicsCommandContext): MutableList<String> {
-        return Arrays.stream(ChatColor.values()).map { it.name }.collect(Collectors.toList())
+        return if(context.args.size == 1) {
+            Arrays.stream(ChatColor.values()).map { it.name.lowercase() }.toList().addAnd("reset")
+                .partialMatches(context.args[0])
+        } else {
+            mutableListOf()
+        }
     }
 }

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/commmands/ColorChatCommand.kt
@@ -1,0 +1,42 @@
+package com.github.spigotbasics.modules.basicschatformat.commmands
+
+import com.github.spigotbasics.core.command.BasicsCommandContext
+import com.github.spigotbasics.core.command.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.CommandResult
+import com.github.spigotbasics.modules.basicschatformat.BasicsChatFormatModule
+import net.md_5.bungee.api.ChatColor
+import org.bukkit.entity.Player
+import java.util.Arrays
+import java.util.stream.Collectors
+
+class ColorChatCommand(private val module: BasicsChatFormatModule) : BasicsCommandExecutor(module) {
+    override fun execute(context: BasicsCommandContext): CommandResult {
+        if (context.sender !is Player) {
+            module.plugin.messages.commandNotFromConsole.sendToSender(context.sender)
+            return CommandResult.SUCCESS
+        }
+        val player = context.sender as Player
+
+        var color = module.messageColor
+        if (context.args.size == 1) {
+            color = context.args[0]
+        } else if (context.args.size > 1) {
+            return CommandResult.USAGE
+        }
+
+        if (color != module.messageColor && !module.regex.matches(color)) {
+            module.messages.colorInvalid(color).sendToSender(player)
+            return CommandResult.SUCCESS
+        }
+
+        val chatDatum = module.getChatData(player.uniqueId)
+        chatDatum.color = color
+        module.messages.colorSet(color).sendToSender(player)
+
+        return CommandResult.SUCCESS
+    }
+
+    override fun tabComplete(context: BasicsCommandContext): MutableList<String> {
+        return Arrays.stream(ChatColor.values()).map { it.name }.collect(Collectors.toList())
+    }
+}

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
@@ -1,0 +1,3 @@
+package com.github.spigotbasics.modules.basicschatformat.data
+
+class ChatData(var color: String)

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
@@ -1,3 +1,3 @@
 package com.github.spigotbasics.modules.basicschatformat.data
 
-data class ChatData(val color: String)
+data class ChatData(var color: String)

--- a/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
+++ b/modules/basics-chat-format/src/main/kotlin/com/github/spigotbasics/modules/basicschatformat/data/ChatData.kt
@@ -1,3 +1,3 @@
 package com.github.spigotbasics.modules.basicschatformat.data
 
-class ChatData(var color: String)
+data class ChatData(val color: String)

--- a/modules/basics-chat-format/src/main/resources/config.yml
+++ b/modules/basics-chat-format/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # Tags: <#message> <#message-color>
 chat-format: "<player-dm> <dark_text>»<reset> <#message-color><#message>"
-message-color: "<white>"
+default-message-color: "white"
 
 # Color names that match this regex will be blacklisted
 regex-blacklist: "^(?!\\bbold\\b|\\bb\\b|\\bitalic\\b|\\bem\\b|\\bi\\b|\\bunderlined\\b|\\bu\\b|\\bstrikethrough\\b|\\bst\\b|\\bobfuscated\\b|\\bobf\\b).*$"

--- a/modules/basics-chat-format/src/main/resources/config.yml
+++ b/modules/basics-chat-format/src/main/resources/config.yml
@@ -1,2 +1,8 @@
-# Tags: <#message>
-chat-format: "<player-dm> <dark_text>»<reset> <#message>"
+# Tags: <#message> <#message-color>
+chat-format: "<player-dm> <dark_text>»<reset> <#message-color><#message>"
+message-color: "<white>"
+
+# Color names that match this regex will be blacklisted
+regex-blacklist: "^(?!\\bbold\\b|\\bb\\b|\\bitalic\\b|\\bem\\b|\\bi\\b|\\bunderlined\\b|\\bu\\b|\\bstrikethrough\\b|\\bst\\b|\\bobfuscated\\b|\\bobf\\b).*$"
+# Color names that match this regex are whitelisted | when in use blacklist is ignored | Comment out to turn off
+regex-whitelist: "(\\b(black|dark_blue|dark_green|dark_red|dark_purple|gold|gray|dark_gray|blue|green|aqua|red|light_purple|yellow|white)\\b|#[0-9a-fA-F]{6}|gradient:#[0-9a-fA-F]{6}:#[0-9a-fA-F]{6})"

--- a/modules/basics-chat-format/src/main/resources/messages.yml
+++ b/modules/basics-chat-format/src/main/resources/messages.yml
@@ -2,3 +2,5 @@
 color-set: "<def_text>Set your chat color to <#selected-color-parsed><#selected-color-name>!</def_text>"
 # Tags: <#selected-color-name>
 color-invalid: "<error><error_red>The given color name <bright_red><#selected-color-name></bright_red> is invalid</error_red>"
+
+color-reset: "<dark_text>Reset your chat color to default.</dark_text>"

--- a/modules/basics-chat-format/src/main/resources/messages.yml
+++ b/modules/basics-chat-format/src/main/resources/messages.yml
@@ -1,0 +1,4 @@
+# Tags: <#selected-color-name>, <#selected-color-parsed>
+color-set: "<def_text>Set your chat color to <#selected-color-parsed><#selected-color-name>!</def_text>"
+# Tags: <#selected-color-name>
+color-invalid: "<error><error_red>The given color name <bright_red><#selected-color-name></bright_red> is invalid</error_red>"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -36,6 +36,9 @@ tasks.shadowJar {
 
     minimize {
         exclude(project(":core"))
+        exclude(project(":pipe:facade"))
+        exclude(project(":pipe:spigot"))
+        exclude(project(":pipe:paper"))
     }
 }
 


### PR DESCRIPTION
#98 

Changes:

- Command is called /chatcolor, not /setcolor
- `/chatcolor reset` to reset the color. This removes the data instead of setting it to the default value, so that players won't be stuck with the original default value that was once set
- Simplified saving/loading data