### PR TITLE
Set version to git commit hash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-version = "0.0.4-SNAPSHOT"
+version = "git-${getGitCommitHash()}"
 
 plugins {
     base


### PR DESCRIPTION
This automatically sets the project version to the current git commit (short) hash. This allows to easily create releases by pushing a tag, without having to adjust the version manually for any builds inbetween.