### PR TITLE
Allow CommandContextExecutors per ArgumentPath!

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ Debug output can be enabled by setting the `BASICS_DEBUG_LEVEL` environment vari
 ```shell
 BASICS_DEBUG_LEVEL=99 java -jar spigot.jar 
 ```
+
+You can also change the debug level on the fly using `/basicsdebug setdebugloglevel <number>`.

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ArgumentPath.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ArgumentPath.kt
@@ -16,6 +16,7 @@ class ArgumentPath<T : CommandContext>(
     val arguments: List<Pair<String, CommandArgument<*>>>,
     val permission: List<Permission> = emptyList(),
     private val contextBuilder: (Map<String, Any?>) -> T,
+    val ownExecutor: CommandContextExecutor<T>? = null,
 ) {
     companion object {
         val logger = BasicsLoggerFactory.getCoreLogger(ArgumentPath::class)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ParsedCommandExecutor.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ParsedCommandExecutor.kt
@@ -9,7 +9,7 @@ import org.bukkit.command.CommandSender
 import org.bukkit.permissions.Permission
 
 class ParsedCommandExecutor<T : CommandContext>(
-    private val executor: CommandContextExecutor<T>,
+    private val executor: CommandContextExecutor<T>?,
     private val paths: List<ArgumentPath<T>>,
 ) {
     companion object {
@@ -78,7 +78,10 @@ class ParsedCommandExecutor<T : CommandContext>(
                 when (val result = path.parse(sender, input)) {
                     is ParseResult.Success -> {
                         logger.debug(10, "Path.parse == ParseResult.Success: $result")
-                        executor.execute(sender, result.context)
+
+                        val actualExecutor = path.ownExecutor ?: executor ?: error("No executor found for path: $path")
+
+                        actualExecutor.execute(sender, result.context)
                         // logger.debug(10,"Command executed successfully.")
                         logger.debug(10, "Command executed successfully.")
                         return Either.Left(CommandResult.SUCCESS)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ParsedCommandExecutor.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/ParsedCommandExecutor.kt
@@ -17,6 +17,16 @@ class ParsedCommandExecutor<T : CommandContext>(
     }
 
     init {
+
+        for (path in paths) {
+            if (path.ownExecutor == null && executor == null) {
+                throw IllegalArgumentException(
+                    "Attempting to create a ParsedCommandExecutor with a path that has no executor and no default " +
+                        "executor was provided. Path: $path",
+                )
+            }
+        }
+
         logger.debug(10, "ParsedCommandExecutor created with paths: ${paths.size}")
     }
 

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/IntArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/IntArg.kt
@@ -1,5 +1,7 @@
 package com.github.spigotbasics.core.command.parsed.arguments
 
+import com.github.spigotbasics.core.Basics
+import com.github.spigotbasics.core.messages.Message
 import org.bukkit.command.CommandSender
 
 open class IntArg(name: String) : CommandArgument<Int>(name) {
@@ -7,4 +9,11 @@ open class IntArg(name: String) : CommandArgument<Int>(name) {
         sender: CommandSender,
         value: String,
     ): Int? = value.toIntOrNull()
+
+    override fun errorMessage(
+        sender: CommandSender,
+        value: String,
+    ): Message {
+        return Basics.messages.invalidValueForArgumentMustBeInteger(name, value)
+    }
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/IntRangeArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/IntRangeArg.kt
@@ -21,6 +21,7 @@ class IntRangeArg(name: String, private val min: () -> Int, private val max: () 
         sender: CommandSender,
         value: String,
     ): Message {
-        return Basics.messages.invalidValueForArgumentNumberNotInRange(name, value.toIntOrNull() ?: 0, min(), max())
+        val given = value.toIntOrNull() ?: return Basics.messages.invalidValueForArgumentMustBeInteger(name, value)
+        return Basics.messages.invalidValueForArgumentNumberNotInRange(name, given, min(), max())
     }
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/PlayersArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/PlayersArg.kt
@@ -5,6 +5,7 @@ import com.github.spigotbasics.common.leftOrNull
 import com.github.spigotbasics.core.Basics
 import com.github.spigotbasics.core.extensions.partialMatches
 import com.github.spigotbasics.core.messages.Message
+import com.github.spigotbasics.core.permission.CorePermissions
 import org.bukkit.Bukkit
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
@@ -16,7 +17,7 @@ class PlayersArg(name: String) : CommandArgument<List<Player>>(name) {
         SELECTOR_INCUDES_ENTITIES,
     }
 
-    private val selectorPermission = Basics.permissions.useSelectors
+    private val selectorPermission = CorePermissions.useSelectors
 
     override fun parse(
         sender: CommandSender,

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/PlayersArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/PlayersArg.kt
@@ -14,7 +14,7 @@ class PlayersArg(name: String) : CommandArgument<List<Player>>(name) {
     private enum class ErrorType {
         NOT_FOUND,
         NO_PERMISSION_SELECTORS,
-        SELECTOR_INCUDES_ENTITIES,
+        SELECTOR_INCLUDES_ENTITIES,
     }
 
     private val selectorPermission = CorePermissions.useSelectors
@@ -59,7 +59,7 @@ class PlayersArg(name: String) : CommandArgument<List<Player>>(name) {
         val selected = Bukkit.selectEntities(sender, value)
         val players = selected.filterIsInstance<Player>()
         if (selected.size != players.size) {
-            return Either.Left(ErrorType.SELECTOR_INCUDES_ENTITIES)
+            return Either.Left(ErrorType.SELECTOR_INCLUDES_ENTITIES)
         }
         if (players.isEmpty()) {
             return Either.Left(ErrorType.NOT_FOUND)
@@ -74,7 +74,7 @@ class PlayersArg(name: String) : CommandArgument<List<Player>>(name) {
         return when (get(sender, value).leftOrNull()) {
             ErrorType.NOT_FOUND -> Basics.messages.playerNotFound(value)
             ErrorType.NO_PERMISSION_SELECTORS -> Basics.messages.noPermission(selectorPermission)
-            ErrorType.SELECTOR_INCUDES_ENTITIES -> Basics.messages.selectorIncludesEntities(value)
+            ErrorType.SELECTOR_INCLUDES_ENTITIES -> Basics.messages.selectorIncludesEntities(value)
             else -> super.errorMessage(sender, value)
         }
     }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/ArgumentPathBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/ArgumentPathBuilder.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.core.command.parsed.dsl.argumentpathbuilder
 
 import com.github.spigotbasics.core.command.parsed.AnySender
 import com.github.spigotbasics.core.command.parsed.ArgumentPath
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
 import com.github.spigotbasics.core.command.parsed.PlayerSender
 import com.github.spigotbasics.core.command.parsed.SenderType
 import com.github.spigotbasics.core.command.parsed.arguments.CommandArgument
@@ -13,6 +14,7 @@ abstract class ArgumentPathBuilder<T : CommandContext> {
     protected var senderType: SenderType<*> = AnySender
     protected var arguments = emptyList<Pair<String, CommandArgument<*>>>()
     protected var permissions = emptyList<Permission>()
+    protected var pathExecutor: CommandContextExecutor<T>? = null
 
     private fun senderType(senderType: SenderType<*>) = apply { this.senderType = senderType }
 
@@ -28,6 +30,8 @@ abstract class ArgumentPathBuilder<T : CommandContext> {
             argumentBuilder.block()
             this.arguments = argumentBuilder.build()
         }
+
+    fun executor(pathExecutor: CommandContextExecutor<T>) = apply { this.pathExecutor = pathExecutor }
 
     abstract fun build(): ArgumentPath<T>
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/GenericArgumentPathBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/GenericArgumentPathBuilder.kt
@@ -1,6 +1,7 @@
 package com.github.spigotbasics.core.command.parsed.dsl.argumentpathbuilder
 
 import com.github.spigotbasics.core.command.parsed.ArgumentPath
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
 import com.github.spigotbasics.core.command.parsed.context.CommandContext
 
 class GenericArgumentPathBuilder<T : CommandContext> : ArgumentPathBuilder<T>() {
@@ -14,5 +15,6 @@ class GenericArgumentPathBuilder<T : CommandContext> : ArgumentPathBuilder<T>() 
             arguments,
             permissions,
             contextBuilder ?: error("Context builder not set"),
+            pathExecutor
         )
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/GenericArgumentPathBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/GenericArgumentPathBuilder.kt
@@ -1,7 +1,6 @@
 package com.github.spigotbasics.core.command.parsed.dsl.argumentpathbuilder
 
 import com.github.spigotbasics.core.command.parsed.ArgumentPath
-import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
 import com.github.spigotbasics.core.command.parsed.context.CommandContext
 
 class GenericArgumentPathBuilder<T : CommandContext> : ArgumentPathBuilder<T>() {
@@ -15,6 +14,6 @@ class GenericArgumentPathBuilder<T : CommandContext> : ArgumentPathBuilder<T>() 
             arguments,
             permissions,
             contextBuilder ?: error("Context builder not set"),
-            pathExecutor
+            pathExecutor,
         )
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/MapArgumentPathBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/argumentpathbuilder/MapArgumentPathBuilder.kt
@@ -9,5 +9,7 @@ class MapArgumentPathBuilder : ArgumentPathBuilder<MapContext>() {
             senderType,
             arguments,
             permissions,
-        ) { args -> MapContext(args) }
+            { args -> MapContext(args) },
+            pathExecutor,
+        )
 }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/commandbuilder/ParsedCommandBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/commandbuilder/ParsedCommandBuilder.kt
@@ -87,7 +87,7 @@ open class ParsedCommandBuilder<T : CommandContext>(
     fun build(): BasicsCommand {
         val command =
             ParsedCommandExecutor(
-                parsedExecutor, // ?: error("parsedExecutor must be set"),
+                parsedExecutor,
                 argumentPaths,
             )
         val actualExecutor = createActualExecutor(command)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/commandbuilder/ParsedCommandBuilder.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/dsl/commandbuilder/ParsedCommandBuilder.kt
@@ -87,7 +87,7 @@ open class ParsedCommandBuilder<T : CommandContext>(
     fun build(): BasicsCommand {
         val command =
             ParsedCommandExecutor(
-                parsedExecutor ?: error("parsedExecutor must be set"),
+                parsedExecutor, // ?: error("parsedExecutor must be set"),
                 argumentPaths,
             )
         val actualExecutor = createActualExecutor(command)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/messages/CoreMessages.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/messages/CoreMessages.kt
@@ -58,6 +58,15 @@ class CoreMessages(context: ConfigInstantiationContext) : SavedConfig(context) {
             .tagUnparsed("value", givenValue)
     }
 
+    fun invalidValueForArgumentMustBeInteger(
+        argumentName: String,
+        givenValue: String,
+    ): Message {
+        return getMessage("invalid-value-for-argument-must-be-integer")
+            .tagUnparsed("argument", argumentName)
+            .tagUnparsed("value", givenValue)
+    }
+
     fun invalidValueForArgumentNumberNotInRange(
         argumentName: String,
         givenValue: Int,
@@ -66,9 +75,9 @@ class CoreMessages(context: ConfigInstantiationContext) : SavedConfig(context) {
     ): Message {
         return getMessage("invalid-value-for-argument-number-not-in-range")
             .tagUnparsed("argument", argumentName)
-            .tagParsed("value", givenValue.toString())
-            .tagParsed("min", min.toString())
-            .tagParsed("max", max.toString())
+            .tagUnparsed("value", givenValue.toString())
+            .tagUnparsed("min", min.toString())
+            .tagUnparsed("max", max.toString())
     }
 
     fun missingArgument(name: String) = getMessage("missing-value-for-argument").tagParsed("argument", name)

--- a/core/src/main/kotlin/com/github/spigotbasics/core/permission/CorePermissions.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/permission/CorePermissions.kt
@@ -1,8 +1,12 @@
 package com.github.spigotbasics.core.permission
 
-class CorePermissions(private val permissionManager: BasicsPermissionManager) {
+import com.github.spigotbasics.core.logger.BasicsLoggerFactory
+
+object CorePermissions {
+    private val pm = BasicsPermissionManager(BasicsLoggerFactory.getCoreLogger(CorePermissions::class))
+
     val useSelectors =
-        permissionManager.createSimplePermission(
+        pm.createSimplePermission(
             "basics.selectors",
             "Allows using selectors (@p, etc)",
         )

--- a/core/src/main/resources/messages.yml
+++ b/core/src/main/resources/messages.yml
@@ -9,6 +9,7 @@ unknown-option: "<error><red>Unknown option: </red><color:#FF8888><#option></col
 
 # Tags: <#argument> <#value>
 invalid-value-for-argument: "<error><red>Invalid value for <bright_red><#argument></bright_red>: <bright_red><#value></bright_red></red>"
+invalid-value-for-argument-must-be-integer: "<error><red>Invalid value for <bright_red><#argument></bright_red>: Must be an integer, was <dark_red><#value></dark_red>!</red>"
 
 # Tags: <#argument> <#value> <#min> <#max>
 invalid-value-for-argument-number-not-in-range: "<error><red>Invalid value for <bright_red><#argument></bright_red>: Must be between <bright_red><#min></bright_red> and <bright_red><#max></bright_red>, was <dark_red><#value></dark_red>!</red>"

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
@@ -5,15 +5,22 @@ import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
 import org.bukkit.permissions.PermissionDefault
 
 class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
-    val permission =
+    val modulePermission =
         permissionManager.createSimplePermission(
             "basics.admin.module",
             "Allows managing Basics modules",
             PermissionDefault.OP,
         )
 
+    val debugPermission =
+        permissionManager.createSimplePermission(
+            "basics.admin.debug",
+            "Allows debugging Basics",
+            PermissionDefault.OP,
+        )
+
     override fun onEnable() {
-        commandFactory.parsedCommandBuilder("module", permission)
+        commandFactory.parsedCommandBuilder("module", modulePermission)
             .mapContext {
                 usage = "<command> [module]"
 
@@ -91,6 +98,20 @@ class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModu
                 path {}
             }
             .executor(ModuleCommand(this))
+            .register()
+
+        commandFactory.parsedCommandBuilder("basicsdebug", debugPermission)
+            .mapContext {
+                usage = "<command>"
+
+                path {
+                    arguments {
+                        sub("printpermissions")
+                    }
+                    executor(PrintPermissionsCommand())
+                }
+            }
+            //.executor(DebugFallbackExecutor())
             .register()
     }
 }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/BasicsCoreModule.kt
@@ -1,7 +1,10 @@
 package com.github.spigotbasics.modules.basicscore
 
+import com.github.spigotbasics.core.command.parsed.arguments.IntRangeArg
 import com.github.spigotbasics.core.module.AbstractBasicsModule
 import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
+import com.github.spigotbasics.modules.basicscore.commands.PrintPermissionsCommand
+import com.github.spigotbasics.modules.basicscore.commands.SetDebugLogLevelCommand
 import org.bukkit.permissions.PermissionDefault
 
 class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
@@ -110,8 +113,15 @@ class BasicsCoreModule(context: ModuleInstantiationContext) : AbstractBasicsModu
                     }
                     executor(PrintPermissionsCommand())
                 }
+
+                path {
+                    arguments {
+                        sub("setdebugloglevel")
+                        named("level", IntRangeArg("Log Level", { 0 }, { 999_999_999 }))
+                    }
+                    executor(SetDebugLogLevelCommand())
+                }
             }
-            //.executor(DebugFallbackExecutor())
             .register()
     }
 }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/DebugFallbackExecutor.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/DebugFallbackExecutor.kt
@@ -1,0 +1,11 @@
+package com.github.spigotbasics.modules.basicscore
+
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
+import com.github.spigotbasics.core.command.parsed.context.MapContext
+import org.bukkit.command.CommandSender
+
+class DebugFallbackExecutor : CommandContextExecutor<MapContext> {
+    override fun execute(sender: CommandSender, context: MapContext) {
+        throw IllegalStateException("This command should never be executed")
+    }
+}

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/PrintPermissionsCommand.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/PrintPermissionsCommand.kt
@@ -1,0 +1,13 @@
+package com.github.spigotbasics.modules.basicscore
+
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
+import com.github.spigotbasics.core.command.parsed.context.MapContext
+import org.bukkit.command.CommandSender
+
+class PrintPermissionsCommand : CommandContextExecutor<MapContext> {
+    override fun execute(sender: CommandSender, context: MapContext) {
+        for(permission in sender.server.pluginManager.permissions.filter { it.name.startsWith("basics.") }.sortedBy { it.name }) {
+            sender.sendMessage(permission.name + " - " + permission.description + " - " + permission.default.toString())
+        }
+    }
+}

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/DebugFallbackExecutor.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/DebugFallbackExecutor.kt
@@ -1,11 +1,14 @@
-package com.github.spigotbasics.modules.basicscore
+package com.github.spigotbasics.modules.basicscore.commands
 
 import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
 import com.github.spigotbasics.core.command.parsed.context.MapContext
 import org.bukkit.command.CommandSender
 
 class DebugFallbackExecutor : CommandContextExecutor<MapContext> {
-    override fun execute(sender: CommandSender, context: MapContext) {
+    override fun execute(
+        sender: CommandSender,
+        context: MapContext,
+    ) {
         throw IllegalStateException("This command should never be executed")
     }
 }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/PrintPermissionsCommand.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/PrintPermissionsCommand.kt
@@ -1,12 +1,15 @@
-package com.github.spigotbasics.modules.basicscore
+package com.github.spigotbasics.modules.basicscore.commands
 
 import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
 import com.github.spigotbasics.core.command.parsed.context.MapContext
 import org.bukkit.command.CommandSender
 
 class PrintPermissionsCommand : CommandContextExecutor<MapContext> {
-    override fun execute(sender: CommandSender, context: MapContext) {
-        for(permission in sender.server.pluginManager.permissions.filter { it.name.startsWith("basics.") }.sortedBy { it.name }) {
+    override fun execute(
+        sender: CommandSender,
+        context: MapContext,
+    ) {
+        for (permission in sender.server.pluginManager.permissions.filter { it.name.startsWith("basics.") }.sortedBy { it.name }) {
             sender.sendMessage(permission.name + " - " + permission.description + " - " + permission.default.toString())
         }
     }

--- a/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/SetDebugLogLevelCommand.kt
+++ b/modules/basics-core/src/main/kotlin/com/github/spigotbasics/modules/basicscore/commands/SetDebugLogLevelCommand.kt
@@ -1,0 +1,16 @@
+package com.github.spigotbasics.modules.basicscore.commands
+
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
+import com.github.spigotbasics.core.command.parsed.context.MapContext
+import com.github.spigotbasics.core.logger.BasicsLogger
+import org.bukkit.command.CommandSender
+
+class SetDebugLogLevelCommand : CommandContextExecutor<MapContext> {
+    override fun execute(
+        sender: CommandSender,
+        context: MapContext,
+    ) {
+        BasicsLogger.debugLogLevel = context["level"] as Int
+        sender.sendMessage("Debug log level set to ${context["level"]}")
+    }
+}

--- a/modules/basics-workbench/src/main/kotlin/com/github/spigotbasics/modules/basicsworkbench/BasicsWorkbenchModule.kt
+++ b/modules/basics-workbench/src/main/kotlin/com/github/spigotbasics/modules/basicsworkbench/BasicsWorkbenchModule.kt
@@ -54,7 +54,7 @@ class BasicsWorkbenchModule(context: ModuleInstantiationContext) : AbstractBasic
     override fun onEnable() {
         commandFactory.rawCommandBuilder("craftingtable", permissionCraftingTable)
             .description("Opens a crafting table")
-            .aliases(listOf("workbench"))
+//            .aliases(listOf("workbench"))
             .executor(WorkbenchExecutor())
             .register()
 

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -137,7 +137,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
         server.pluginManager.registerEvents(modulePlayerDataLoader, this)
         server.pluginManager.registerEvents(PlayerCommandListSendListener(facade.getCommandMap(server.pluginManager)), this)
 
-        getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
+        //getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
     }
 
     private fun initializeHeavyClasses() {

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -18,7 +18,6 @@ import com.github.spigotbasics.core.messages.CoreMessages
 import com.github.spigotbasics.core.messages.MessageFactory
 import com.github.spigotbasics.core.messages.tags.TagResolverFactory
 import com.github.spigotbasics.core.module.manager.ModuleManager
-import com.github.spigotbasics.core.permission.BasicsPermissionManager
 import com.github.spigotbasics.core.permission.CorePermissions
 import com.github.spigotbasics.core.playerdata.CorePlayerData
 import com.github.spigotbasics.core.playerdata.CorePlayerDataListener
@@ -50,7 +49,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
 
     private val logger = BasicsLoggerFactory.getCoreLogger(this::class)
 
-    override val permissions = CorePermissions(BasicsPermissionManager(logger))
+    override val permissions = CorePermissions
     override val moduleFolder = File(dataFolder, "modules")
     override val moduleManager = ModuleManager(this, server, moduleFolder)
     override val tagResolverFactory: TagResolverFactory = TagResolverFactory(facade)

--- a/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
+++ b/plugin/src/main/kotlin/com/github/spigotbasics/plugin/BasicsPluginImpl.kt
@@ -137,7 +137,7 @@ class BasicsPluginImpl : JavaPlugin(), BasicsPlugin {
         server.pluginManager.registerEvents(modulePlayerDataLoader, this)
         server.pluginManager.registerEvents(PlayerCommandListSendListener(facade.getCommandMap(server.pluginManager)), this)
 
-        //getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
+        // getCommand("basicsdebug")?.setExecutor(BasicsDebugCommand(this))
     }
 
     private fun initializeHeavyClasses() {

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: com.github.spigotbasics.plugin.BasicsPluginImpl
 api-version: "1.13"
 authors: [ "https://github.com/SpigotBasics/basics/graphs/contributors" ]
 commands:
-  basicsdebug:
-    description: "Debugging commands for Basics"
-    permission: basics.debug
-    usage: "/<command> [start <interval>|stop]"
+#  basicsdebug:
+#    description: "Debugging commands for Basics"
+#    permission: basics.debug
+#    usage: "/<command> [start <interval>|stop]"


### PR DESCRIPTION
This allows to set a custom CommandContextExecutor for each ArgumentPath! If none is set, it'll fall back to the parent CommandContextExecutor.

The ParsedCommandExecutor checks during its creation whether there's any paths left that don't have any executor set, and if yes, it'll throw an error if there's also no parent executor set.

Example:

```kotlin
commandFactory.parsedCommandBuilder("testcommand", commandBasePermission)
    .mapContext {
        usage = "<subcommand>"
        
        path {
            arguments {
                sub("firstsubcommand")
            }
            
            executor(SubCommand1Executor()) // Only executes this path
        }
        
        path {
            arguments {
                sub("secondsubcommand")
            }
            
            // No executor set, falls back to the default executor
        }
        
        path {
            // This path does not have any arguments
            permissions(permissionForNoArgumentsPath) // But it requires an extra permission...
            playerOnly() // And is only available to players
        }
        
    }
    .executor(FallbackExecutor()) // Only needed if there's any path without their own executor
    .register()
```