### PR TITLE
Added TripleContextCoordinates

### DIFF
--- a/buildSrc/src/main/kotlin/basics.module.gradle.kts
+++ b/buildSrc/src/main/kotlin/basics.module.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 apply(plugin = "com.github.johnrengelman.shadow")
 
 dependencies {
+    compileOnly(project(":common"))
     compileOnly(project(":core"))
 }
 

--- a/common/src/main/kotlin/com/github/spigotbasics/common/Either.kt
+++ b/common/src/main/kotlin/com/github/spigotbasics/common/Either.kt
@@ -1,5 +1,8 @@
 package com.github.spigotbasics.common
 
+import com.github.spigotbasics.common.Either.Left
+import com.github.spigotbasics.common.Either.Right
+
 /**
  * Represents a value of one of two possible types (a disjoint union).
  * Instances of [Either] are either an instance of [Left] or [Right].
@@ -67,6 +70,48 @@ sealed class Either<out L, out R> {
      * @return The right value, or null if this is a [Either.Left].
      */
     fun rightOrNull(): R? = (this as? Either.Right<R>)?.value
+
+    /**
+     * Transforms the value inside this [Either] if it's a [Left] by applying [transform] to it.
+     *
+     * @param transform The transformation function to apply to the [Left] value.
+     * @return An [Either] containing the transformed [Left] value, or the original [Right] value if this is a [Right].
+     */
+    fun <NewL> mapLeft(transform: (L) -> NewL): Either<NewL, R> =
+        when (this) {
+            is Left -> Left(transform(value))
+            is Right -> this
+        }
+
+    /**
+     * Transforms the value inside this [Either] if it's a [Right] by applying [transform] to it.
+     *
+     * @param transform The transformation function to apply to the [Right] value.
+     * @return An [Either] containing the transformed [Right] value, or the original [Left] value if this is a [Left].
+     */
+    fun <NewR> mapRight(transform: (R) -> NewR): Either<L, NewR> =
+        when (this) {
+            is Left -> this
+            is Right -> Right(transform(value))
+        }
+
+    /**
+     * Transforms the values inside this [Either], applying [transformLeft] if it's a [Left]
+     * or [transformRight] if it's a [Right].
+     *
+     * @param transformLeft The transformation function to apply to the [Left] value.
+     * @param transformRight The transformation function to apply to the [Right] value.
+     * @return An [Either] containing the transformed value.
+     */
+    fun <NewL, NewR> mapBoth(
+        transformLeft: (L) -> NewL,
+        transformRight: (R) -> NewR
+    ): Either<NewL, NewR> =
+        when (this) {
+            is Left -> Left(transformLeft(value))
+            is Right -> Right(transformRight(value))
+        }
+
 
     companion object {
         /**

--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/TripleContextCoordinatesArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/TripleContextCoordinatesArg.kt
@@ -1,0 +1,17 @@
+package com.github.spigotbasics.core.command.parsed.arguments
+
+import com.github.spigotbasics.core.model.TripleContextCoordinates
+import org.bukkit.command.CommandSender
+
+class TripleContextCoordinatesArg(name: String) : CommandArgument<TripleContextCoordinates>(name) {
+    override fun parse(sender: CommandSender, value: String): TripleContextCoordinates? {
+        return try {
+            TripleContextCoordinates.parse(value)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override val greedy = true
+    override val length = 3
+}

--- a/core/src/main/kotlin/com/github/spigotbasics/core/extensions/StringUtils.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/extensions/StringUtils.kt
@@ -6,3 +6,5 @@ import org.bukkit.util.StringUtil
 fun String.startsWithIgnoreCase(prefix: String) = StringUtil.startsWithIgnoreCase(this, prefix)
 
 fun String.toHumanReadable() = TextFormatter.toHumanReadable(this)
+
+fun String.toZeroWhenEmpty() = ifEmpty { "0" }

--- a/core/src/main/kotlin/com/github/spigotbasics/core/model/TripleContextCoordinates.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/model/TripleContextCoordinates.kt
@@ -1,0 +1,96 @@
+package com.github.spigotbasics.core.model
+
+import com.github.spigotbasics.core.extensions.toZeroWhenEmpty
+import org.bukkit.Location
+
+data class TripleContextCoordinates(
+    val x: Double,
+    val xRelative: Relativity,
+    val y: Double,
+    val yRelative: Relativity,
+    val z: Double,
+    val zRelative: Relativity,
+    val yaw: Float = 0f,
+    val yawRelative: Relativity = Relativity.RELATIVE_TO_FIRST,
+    val pitch: Float = 0f,
+    val pitchRelative: Relativity = Relativity.RELATIVE_TO_FIRST,
+) {
+
+    enum class Relativity {
+        ABSOLUTE,
+        RELATIVE_TO_FIRST,
+        RELATIVE_TO_SECOND,
+    }
+
+    fun toLocation(first: Location, second: Location = first): Location {
+        val nX = applyRelativity(xRelative, x, first.x, second.x)
+        val nY = applyRelativity(yRelative, y, first.y, second.y)
+        val nZ = applyRelativity(zRelative, z, first.z, second.z)
+        val nYaw = applyRelativity(yawRelative, yaw, first.yaw, second.yaw)
+        val nPitch = applyRelativity(pitchRelative, pitch, first.pitch, second.pitch)
+        return Location(first.world, nX, nY, nZ, nYaw, nPitch)
+    }
+
+    companion object {
+        fun parse(string: String): TripleContextCoordinates {
+            val parts = string.split(" ")
+            val (x, xRelative) = parseSingle(parts[0])
+            val (y, yRelative) = parseSingle(parts[1])
+            val (z, zRelative) = parseSingle(parts[2])
+
+            val (yaw, yawRelative) = if (parts.size > 3) {
+                parseSingle(parts[3])
+            } else {
+                Pair(0.0, Relativity.RELATIVE_TO_FIRST)
+            }
+
+            val (pitch, pitchRelative) = if (parts.size > 4) {
+                parseSingle(parts[4])
+            } else {
+                Pair(0.0, Relativity.RELATIVE_TO_FIRST)
+            }
+
+
+
+            return TripleContextCoordinates(
+                x,
+                xRelative,
+                y,
+                yRelative,
+                z,
+                zRelative,
+                yaw.toFloat(),
+                yawRelative,
+                pitch.toFloat(),
+                pitchRelative,
+            )
+        }
+
+        fun applyRelativity(relativity: Relativity, value: Double, first: Double, second: Double): Double {
+            return when (relativity) {
+                Relativity.ABSOLUTE -> value
+                Relativity.RELATIVE_TO_FIRST -> first + value
+                Relativity.RELATIVE_TO_SECOND -> second + value
+            }
+        }
+
+        fun applyRelativity(relativity: Relativity, value: Float, first: Float, second: Float): Float {
+            return when (relativity) {
+                Relativity.ABSOLUTE -> value
+                Relativity.RELATIVE_TO_FIRST -> first + value
+                Relativity.RELATIVE_TO_SECOND -> second + value
+            }
+        }
+
+        private fun parseSingle(string: String): Pair<Double, Relativity> {
+            return if (string.startsWith("~~")) {
+                Pair(string.substring(2).toZeroWhenEmpty().toDouble(), Relativity.RELATIVE_TO_SECOND)
+            } else if (string.startsWith("~")) {
+                Pair(string.substring(1).toZeroWhenEmpty().toDouble(), Relativity.RELATIVE_TO_FIRST)
+            } else {
+                Pair(string.toDouble(), Relativity.ABSOLUTE)
+            }
+        }
+    }
+
+}

--- a/modules/basics-tp/src/main/kotlin/com/github/spigotbasics/modules/basicstp/BasicsTpModule.kt
+++ b/modules/basics-tp/src/main/kotlin/com/github/spigotbasics/modules/basicstp/BasicsTpModule.kt
@@ -3,6 +3,7 @@ package com.github.spigotbasics.modules.basicstp
 import com.github.spigotbasics.common.Either
 import com.github.spigotbasics.core.command.parsed.arguments.SelectorMultiEntityArg
 import com.github.spigotbasics.core.command.parsed.arguments.SelectorSingleEntityArg
+import com.github.spigotbasics.core.command.parsed.arguments.TripleContextCoordinatesArg
 import com.github.spigotbasics.core.command.parsed.arguments.XYZCoordsArg
 import com.github.spigotbasics.core.messages.Message
 import com.github.spigotbasics.core.messages.tags.providers.LocationTag
@@ -37,13 +38,13 @@ class BasicsTpModule(context: ModuleInstantiationContext) : AbstractBasicsModule
 
     override fun onEnable() {
         commandFactory.parsedCommandBuilder("tp", permission).mapContext {
-            usage = "[player] <x y z | entity>"
+            usage = "[player] <x y z [yaw pitch]| entity>"
 
             // x y z
             path {
                 playerOnly()
                 arguments {
-                    named("destination", XYZCoordsArg("Destination Coordinates"))
+                    named("destination", TripleContextCoordinatesArg("Destination Coordinates"))
                 }
             }
 
@@ -59,7 +60,7 @@ class BasicsTpModule(context: ModuleInstantiationContext) : AbstractBasicsModule
             path {
                 arguments {
                     named("targets", SelectorMultiEntityArg("Entities to teleport"))
-                    named("destination", XYZCoordsArg("Destination Coordinates"))
+                    named("destination", TripleContextCoordinatesArg("Destination Coordinates"))
                 }
                 permissions(permissionOthers)
             }


### PR DESCRIPTION
Allows to use two forms of relative coordinates:

```
/tp mfnalex ~ ~2 ~ // Teleports mfnalex 2 blocks above the sender
/tp mfnalex ~~ ~~2 ~~ // Teleports mfnalex 2 blocks above himself
```

~ always behaves like in vanilla.
~~ behaves to players like ~ for console.