### PR TITLE
Add Extinguish Module

### DIFF
--- a/modules/basics-extinguish/build.gradle.kts
+++ b/modules/basics-extinguish/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("basics.module")
+}

--- a/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishModule.kt
+++ b/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishModule.kt
@@ -1,0 +1,54 @@
+package com.github.spigotbasics.modules.basicsextinguish
+
+import com.github.spigotbasics.core.command.common.BasicsCommandExecutor
+import com.github.spigotbasics.core.command.common.CommandResult
+import com.github.spigotbasics.core.command.raw.RawCommandContext
+import com.github.spigotbasics.core.module.AbstractBasicsModule
+import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
+
+class BasicsExtinguishModule(context: ModuleInstantiationContext) : AbstractBasicsModule(context) {
+    val permExtinguish =
+        permissionManager.createSimplePermission(
+            "basics.extinguish",
+            "Allows the player to extinguish themself",
+        )
+    val permExtinguishOthers =
+        permissionManager.createSimplePermission(
+            "basics.extinguish.others",
+            "Allows the player to extinguish others",
+        )
+    val messageExtinguished = messages.getMessage("extinguished")
+    val messageExtinguishedOther = messages.getMessage("extinguished-others")
+
+    override fun onEnable() {
+        commandFactory.rawCommandBuilder("extinguish", permExtinguish)
+            .description("Extinguishes Players")
+            .usage("[player]")
+            .aliases(listOf("ext"))
+            .executor(ExtinguishExecutor(this))
+            .register()
+    }
+
+    private inner class ExtinguishExecutor(private val module: BasicsExtinguishModule) : BasicsCommandExecutor(module) {
+        override fun execute(context: RawCommandContext): CommandResult {
+            val player =
+                if (context.args.size == 1) {
+                    requirePermission(context.sender, module.permExtinguishOthers)
+                    requirePlayer(context.args[0])
+                } else {
+                    requirePlayer(context.sender)
+                }
+
+            player.fireTicks = 0
+            val message =
+                if (context.sender == player) {
+                    module.messageExtinguished
+                } else {
+                    module.messageExtinguishedOther
+                }
+
+            message.concerns(player).sendToSender(context.sender)
+            return CommandResult.SUCCESS
+        }
+    }
+}

--- a/modules/basics-extinguish/src/main/resources/basics-module.yml
+++ b/modules/basics-extinguish/src/main/resources/basics-module.yml
@@ -1,0 +1,3 @@
+main-class: com.github.spigotbasics.modules.basicsextinguish.BasicsExtinguishModule
+name: basics-extinguish
+version: ${moduleVersion}

--- a/modules/basics-extinguish/src/main/resources/messages.yml
+++ b/modules/basics-extinguish/src/main/resources/messages.yml
@@ -1,0 +1,2 @@
+extinguished: "<def_text>You have extinguished <lite_text>yourself</lite_text>!</def_text>"
+extinguished-others: "<def_text>You have extinguished <player-dm>!</def_text>"


### PR DESCRIPTION
Extinguish module is fairly simple it adds /extinguish and an alias of that called /ext (Currently not working due to command registration issue), that extinguishes the fire on the player