### PR TITLE
Add Extinguish Module

### DIFF
--- a/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishExecutor.kt
+++ b/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishExecutor.kt
@@ -1,0 +1,25 @@
+package com.github.spigotbasics.modules.basicsextinguish
+
+import com.github.spigotbasics.core.command.parsed.CommandContextExecutor
+import com.github.spigotbasics.core.command.parsed.context.MapContext
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+class BasicsExtinguishExecutor(private val module: BasicsExtinguishModule) : CommandContextExecutor<MapContext> {
+    override fun execute(
+        sender: CommandSender,
+        context: MapContext,
+    ) {
+        val player = context["player"] as Player? ?: sender as Player?
+
+        val msg =
+            if (sender == player) {
+                module.messageExtinguished
+            } else {
+                module.messageExtinguishedOther
+            }
+
+        player?.fireTicks = 0
+        msg.concerns(player).sendToSender(sender)
+    }
+}

--- a/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishModule.kt
+++ b/modules/basics-extinguish/src/main/kotlin/com/github/spigotbasics/modules/basicsextinguish/BasicsExtinguishModule.kt
@@ -2,6 +2,7 @@ package com.github.spigotbasics.modules.basicsextinguish
 
 import com.github.spigotbasics.core.command.common.BasicsCommandExecutor
 import com.github.spigotbasics.core.command.common.CommandResult
+import com.github.spigotbasics.core.command.parsed.arguments.SelectorSinglePlayerArg
 import com.github.spigotbasics.core.command.raw.RawCommandContext
 import com.github.spigotbasics.core.module.AbstractBasicsModule
 import com.github.spigotbasics.core.module.loader.ModuleInstantiationContext
@@ -21,12 +22,23 @@ class BasicsExtinguishModule(context: ModuleInstantiationContext) : AbstractBasi
     val messageExtinguishedOther = messages.getMessage("extinguished-others")
 
     override fun onEnable() {
-        commandFactory.rawCommandBuilder("extinguish", permExtinguish)
-            .description("Extinguishes Players")
-            .usage("[player]")
-            .aliases(listOf("ext"))
-            .executor(ExtinguishExecutor(this))
-            .register()
+        val playerArg = SelectorSinglePlayerArg("Player")
+        commandFactory.parsedCommandBuilder("extinguish", permExtinguish)
+            .mapContext {
+                usage = "[player]"
+                description("Extinguished Players")
+
+                path {
+                    playerOnly()
+                }
+
+                path {
+                    permissions(permExtinguishOthers)
+                    arguments {
+                        named("player", playerArg)
+                    }
+                }
+            }.executor(BasicsExtinguishExecutor(this)).register()
     }
 
     private inner class ExtinguishExecutor(private val module: BasicsExtinguishModule) : BasicsCommandExecutor(module) {


### PR DESCRIPTION
Extinguish module is fairly simple it adds /extinguish and an alias of that called /ext (Currently not working due to command registration issue), that extinguishes the fire on the player