### PR TITLE
Update Paperweight

### DIFF
--- a/nms/versions/1.20.4/build.gradle.kts
+++ b/nms/versions/1.20.4/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("basics.nms-module")
-    id("io.papermc.paperweight.userdev") version "1.7.0"
+    id("io.papermc.paperweight.userdev") version "1.7.1"
 }
 
 dependencies {

--- a/nms/versions/1.20.6/build.gradle.kts
+++ b/nms/versions/1.20.6/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("basics.nms-module")
-    id("io.papermc.paperweight.userdev") version "1.7.0"
+    id("io.papermc.paperweight.userdev") version "1.7.1"
 }
 
 dependencies {


### PR DESCRIPTION
I noticed after a recent paperweight update basics failed to compile. This fixes that.