### PR TITLE
Fix BukkitRegistryArg match overflow

### DIFF
--- a/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/BukkitRegistryArg.kt
+++ b/core/src/main/kotlin/com/github/spigotbasics/core/command/parsed/arguments/BukkitRegistryArg.kt
@@ -1,11 +1,11 @@
 package com.github.spigotbasics.core.command.parsed.arguments
 
+import com.github.spigotbasics.core.extensions.partialMatches
 import org.bukkit.Bukkit
 import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.Registry
 import org.bukkit.command.CommandSender
-import java.util.stream.Collectors
 
 class BukkitRegistryArg<T : Keyed>(name: String, registryClass: Class<T>) : CommandArgument<T>(name) {
     private val registry: Registry<T> = Bukkit.getRegistry(registryClass) ?: error("$registryClass is not a bukkit registry type")
@@ -21,12 +21,12 @@ class BukkitRegistryArg<T : Keyed>(name: String, registryClass: Class<T>) : Comm
         sender: CommandSender,
         typing: String,
     ): List<String> {
-        return registry.stream().map { entry ->
+        return registry.map { entry ->
             val namespacedKeyed = entry.key
             if (namespacedKeyed.namespace == NamespacedKey.MINECRAFT) {
                 return@map namespacedKeyed.key
             }
             return@map namespacedKeyed.toString()
-        }.collect(Collectors.toList())
+        }.partialMatches(typing)
     }
 }


### PR DESCRIPTION
Before: 
![image](https://github.com/SpigotBasics/basics/assets/81843550/595dd6bc-95f5-45ef-b8cd-73d6bf045298)

After: 
![image](https://github.com/SpigotBasics/basics/assets/81843550/60420cf8-e89d-483e-adea-729d72c6d1ea)
